### PR TITLE
Card cost cache fix

### DIFF
--- a/InscryptionCommunityPatch/Card/Part1CardCostRender.cs
+++ b/InscryptionCommunityPatch/Card/Part1CardCostRender.cs
@@ -58,17 +58,7 @@ public static class Part1CardCostRender
 
 	public static Sprite Part1SpriteFinal(CardInfo card)
 	{
-		string costKey = $"b{card.BloodCost}_o{card.BonesCost}_g{card.EnergyCost}_e{GemCost(card)}";
-
-		if (AssembledTextures.ContainsKey(costKey))
-		{
-			if (AssembledTextures[costKey] == null)
-				AssembledTextures.Remove(costKey);
-			else			
-				return TextureHelper.ConvertTexture(AssembledTextures[costKey], TextureHelper.SpriteType.OversizedCostDecal);
-		}
-
-		//A list to hold the textures (important later, to combine them all)
+		// A list to hold the textures (important later, to combine them all)
 		List<Texture2D> list = new List<Texture2D>();
 
 		//Setting mox first
@@ -103,11 +93,10 @@ public static class Part1CardCostRender
 		// Call the event and allow others to modify the list of textures
 		UpdateCardCost?.Invoke(card, list);
 
-		//Combine all the textures from the list into one texture
+		// Combine all the textures from the list into one texture
 		Texture2D finalTexture = CombineCostTextures(list);
 
-		//Convert the final texture to a sprite
-		AssembledTextures.Add(costKey, finalTexture);
+		// Convert the final texture to a sprite
 		return TextureHelper.ConvertTexture(finalTexture, TextureHelper.SpriteType.OversizedCostDecal);
 	}
 

--- a/InscryptionCommunityPatch/Card/Part2CardCostRender.cs
+++ b/InscryptionCommunityPatch/Card/Part2CardCostRender.cs
@@ -17,8 +17,9 @@ public static class Part2CardCostRender
 
     //private static Dictionary<string, Texture2D> AssembledTextures = new();
 
-    public static Texture2D GetFinalTexture(int cardCost, Texture2D artCost, bool left)
+    public static Texture2D CombineIconAndCount(int cardCost, Texture2D artCost)
     {
+        bool left = !PatchPlugin.rightAct2Cost.Value;
         Texture2D baseTexture = TextureHelper.GetImageAsTexture("pixel_blank.png", typeof(Part2CardCostRender).Assembly);
 
         List<Texture2D> list = new List<Texture2D>();
@@ -37,19 +38,21 @@ public static class Part2CardCostRender
         return TextureHelper.CombineTextures(list, baseTexture, xOffset:xOffset, xStep:artCost.width);
     }
 
-    public static Sprite Part2SpriteFinal(CardInfo card, bool left=true)
+    public static Sprite Part2SpriteFinal(CardInfo card)
     {
+        bool left = !PatchPlugin.rightAct2Cost.Value;
+
         // A list to hold the textures (important later, to combine them all)
         List<Texture2D> masterList = new List<Texture2D>();
 
         if (card.BloodCost > 0)
-            masterList.Add(GetFinalTexture(card.BloodCost, TextureHelper.GetImageAsTexture("pixel_blood.png", typeof(Part2CardCostRender).Assembly), left)); 
+            masterList.Add(CombineIconAndCount(card.BloodCost, TextureHelper.GetImageAsTexture("pixel_blood.png", typeof(Part2CardCostRender).Assembly))); 
 
         if (card.BonesCost > 0)
-            masterList.Add(GetFinalTexture(card.BonesCost, TextureHelper.GetImageAsTexture("pixel_bone.png", typeof(Part2CardCostRender).Assembly), left));
+            masterList.Add(CombineIconAndCount(card.BonesCost, TextureHelper.GetImageAsTexture("pixel_bone.png", typeof(Part2CardCostRender).Assembly)));
 
         if (card.EnergyCost > 0)
-            masterList.Add(GetFinalTexture(card.EnergyCost, TextureHelper.GetImageAsTexture("pixel_energy.png", typeof(Part2CardCostRender).Assembly), left));
+            masterList.Add(CombineIconAndCount(card.EnergyCost, TextureHelper.GetImageAsTexture("pixel_energy.png", typeof(Part2CardCostRender).Assembly)));
         
         if (card.gemsCost.Count > 0)
         {
@@ -96,7 +99,7 @@ public static class Part2CardCostRender
 		if (__instance is PixelCardDisplayer) 
 		{ 
 			/// Set the results as the new sprite
-			__result = Part2SpriteFinal(card, !PatchPlugin.rightAct2Cost.Value);
+			__result = Part2SpriteFinal(card);
 			return false;
 		}
 

--- a/InscryptionCommunityPatch/Card/Part2CardCostRender.cs
+++ b/InscryptionCommunityPatch/Card/Part2CardCostRender.cs
@@ -15,7 +15,7 @@ public static class Part2CardCostRender
 
     public static event Action<CardInfo, List<Texture2D>> UpdateCardCost;
 
-    private static Dictionary<string, Texture2D> AssembledTextures = new();
+    //private static Dictionary<string, Texture2D> AssembledTextures = new();
 
     public static Texture2D GetFinalTexture(int cardCost, Texture2D artCost, bool left)
     {
@@ -39,17 +39,7 @@ public static class Part2CardCostRender
 
     public static Sprite Part2SpriteFinal(CardInfo card, bool left=true)
     {
-        string costKey = $"b{card.BloodCost}_o{card.BonesCost}_g{card.EnergyCost}_e{Part1CardCostRender.GemCost(card)}";
-
-        if (AssembledTextures.ContainsKey(costKey))
-		{
-			if (AssembledTextures[costKey] == null)
-				AssembledTextures.Remove(costKey);
-			else			
-				return TextureHelper.ConvertTexture(AssembledTextures[costKey], left ? TextureHelper.SpriteType.Act2CostDecalLeft : TextureHelper.SpriteType.Act2CostDecalRight);
-		}
-
-        //A list to hold the textures (important later, to combine them all)
+        // A list to hold the textures (important later, to combine them all)
         List<Texture2D> masterList = new List<Texture2D>();
 
         if (card.BloodCost > 0)
@@ -92,8 +82,6 @@ public static class Part2CardCostRender
         //Combine all the textures from the list into one texture
         Texture2D baseTexture = TextureHelper.GetImageAsTexture("pixel_base.png", typeof(Part2CardCostRender).Assembly);
         Texture2D finalTexture = TextureHelper.CombineTextures(masterList, baseTexture, yStep:8);
-
-        AssembledTextures.Add(costKey, finalTexture);
 
         //Convert the final texture to a sprite
         Sprite finalSprite = TextureHelper.ConvertTexture(finalTexture, left ? TextureHelper.SpriteType.Act2CostDecalLeft : TextureHelper.SpriteType.Act2CostDecalRight);


### PR DESCRIPTION
As discovered by VoidSlime: custom card cost render was being incorrectly overwritten by poor cache key construction.

I have removed the card cost cache entirely. This was a very minor technical performance improvement in the first place, as the game already has techniques to prevent cards from being re-rendered every frame. Caching the card cost does prevent it from having to be reassembled, but that reassembly doesn't happen very often.

So I've opted to remove the card cost cache entirely. We can keep an eye on performance and see if this creates any issues in the long run but I don't expect it will.