### PR TITLE
Card audit and staticons

### DIFF
--- a/InscryptionAPI/Card/CardExtensions.cs
+++ b/InscryptionAPI/Card/CardExtensions.cs
@@ -345,7 +345,7 @@ public static class CardExtensions
     public static CardInfo SetTail(this CardInfo info, CardInfo tail, Texture2D tailLostPortrait, FilterMode? filterMode = null, IEnumerable<CardModificationInfo> mods = null)
     {
         info.tailParams = new();
-        info.tailParams.tail = CardLoader.Clone(tail);
+        info.tailParams.tail = tail;
 
         if (tailLostPortrait != null)
             info.tailParams.SetLostTailPortrait(tailLostPortrait, info, filterMode);
@@ -402,7 +402,7 @@ public static class CardExtensions
     public static CardInfo SetIceCube(this CardInfo info, CardInfo iceCube, IEnumerable<CardModificationInfo> mods = null)
     {
         info.iceCubeParams = new();
-        info.iceCubeParams.creatureWithin = CardLoader.Clone(iceCube);
+        info.iceCubeParams.creatureWithin = iceCube;
 
         if (mods != null)
             (info.iceCubeParams.creatureWithin.mods = info.iceCubeParams.creatureWithin.mods ?? new ()).AddRange(mods);
@@ -455,7 +455,7 @@ public static class CardExtensions
     public static CardInfo SetEvolve(this CardInfo info, CardInfo evolveCard, int numberOfTurns, IEnumerable<CardModificationInfo> mods = null)
     {
         info.evolveParams = new();
-        info.evolveParams.evolution = CardLoader.Clone(evolveCard);
+        info.evolveParams.evolution = evolveCard;
 
         if (mods != null)
             (info.evolveParams.evolution.mods = info.evolveParams.evolution.mods ?? new ()).AddRange(mods);

--- a/InscryptionAPI/Card/CardExtensions.cs
+++ b/InscryptionAPI/Card/CardExtensions.cs
@@ -347,11 +347,14 @@ public static class CardExtensions
         info.tailParams = new();
         info.tailParams.tail = tail;
 
+        if (mods != null)
+        {
+            info.tailParams.tail = CardLoader.Clone(info.tailParams.tail);
+            (info.tailParams.tail.mods = info.tailParams.tail.mods ?? new()).AddRange(mods);
+        }
+
         if (tailLostPortrait != null)
             info.tailParams.SetLostTailPortrait(tailLostPortrait, info, filterMode);
-
-        if (mods != null)
-            (info.tailParams.tail.mods = info.tailParams.tail.mods ?? new()).AddRange(mods);
 
         return info;
     }
@@ -405,7 +408,10 @@ public static class CardExtensions
         info.iceCubeParams.creatureWithin = iceCube;
 
         if (mods != null)
+        {
+            info.iceCubeParams.creatureWithin = CardLoader.Clone(info.iceCubeParams.creatureWithin);
             (info.iceCubeParams.creatureWithin.mods = info.iceCubeParams.creatureWithin.mods ?? new ()).AddRange(mods);
+        }
 
         return info;
     }
@@ -450,7 +456,7 @@ public static class CardExtensions
     /// </summary>
     /// <param name="evolveCard">The card that will be generated after the set number of turns.</param>
     /// <param name="numberOfTurns">The number of turns before the card evolves</param>
-    /// <param name="mods">A set of card mods to be applied to the evolved card</param>
+    /// <param name="mods">A set of card mods to be applied to the evolved card. If you do this, it will clone the evolve card, which may create unexpected behavior.</param>
     /// <returns></returns>
     public static CardInfo SetEvolve(this CardInfo info, CardInfo evolveCard, int numberOfTurns, IEnumerable<CardModificationInfo> mods = null)
     {
@@ -458,7 +464,10 @@ public static class CardExtensions
         info.evolveParams.evolution = evolveCard;
 
         if (mods != null)
+        {
+            info.evolveParams.evolution = CardLoader.Clone(info.evolveParams.evolution);
             (info.evolveParams.evolution.mods = info.evolveParams.evolution.mods ?? new ()).AddRange(mods);
+        }
 
         info.evolveParams.turnsToEvolve = numberOfTurns;
 

--- a/InscryptionAPI/Card/CardExtensions.cs
+++ b/InscryptionAPI/Card/CardExtensions.cs
@@ -605,6 +605,13 @@ public static class CardExtensions
         return info;
     }
 
+    public static CardInfo SetStatIcon(this CardInfo info, SpecialStatIcon icon)
+    {
+        info.specialStatIcon = icon;
+        info.AddSpecialAbilities(StatIconManager.AllStatIcons.FirstOrDefault(sii => sii.Id == icon).AbilityId);
+        return info;
+    }
+
     /// <summary>
     /// Makes the card fully playable in GBC mode and able to appear in card packs.
     /// </summary>

--- a/InscryptionAPI/Card/CardManager.cs
+++ b/InscryptionAPI/Card/CardManager.cs
@@ -55,6 +55,20 @@ public static class CardManager
     public static void SyncCardList()
     {
         var cards = BaseGameCards.Concat(NewCards).Select(x => CardLoader.Clone(x)).ToList();
+
+        // Fix card copies on params
+        foreach (CardInfo card in cards)
+        {
+            if (card.evolveParams != null && card.evolveParams.evolution != null)
+                card.evolveParams.evolution = cards.CardByName(card.evolveParams.evolution.name);
+
+            if (card.iceCubeParams != null && card.iceCubeParams.creatureWithin != null)
+                card.iceCubeParams.creatureWithin = cards.CardByName(card.iceCubeParams.creatureWithin.name);
+
+            if (card.tailParams != null && card.tailParams.tail != null)
+                card.tailParams.tail = cards.CardByName(card.tailParams.tail.name);
+        }
+
         AllCardsCopy = EventActive ? ModifyCardList?.Invoke(cards) ?? cards : cards;
     }
 

--- a/InscryptionAPI/Encounters/BossManager.cs
+++ b/InscryptionAPI/Encounters/BossManager.cs
@@ -44,7 +44,7 @@ public static class OpponentManager
         foreach (Opponent.Type opponent in Enum.GetValues(typeof(Opponent.Type)))
         {
             string specialSequencerId = useReversePatch ? OriginalGetSequencerIdForBoss(opponent) : BossBattleSequencer.GetSequencerIdForBoss(opponent);
-            Type opponentType = gameAsm.GetType($"DiskCardGame.{opponent.ToString()}Opponent");
+            Type opponentType = gameAsm.GetType($"DiskCardGame.{opponent.ToString()}Opponent") ?? gameAsm.GetType($"GBC.{opponent.ToString()}Opponent");
 
             baseGame.Add(new FullOpponent(opponent, opponentType, specialSequencerId));
         }

--- a/InscryptionAPI/InscryptionAPIPlugin.cs
+++ b/InscryptionAPI/InscryptionAPIPlugin.cs
@@ -75,6 +75,7 @@ public class InscryptionAPIPlugin : BaseUnityPlugin
         CardManager.ActivateEvents();
         CardManager.ResolveMissingModPrefixes();
         ResyncAll();
+        CardManager.AuditCardList();
     }
 
     [HarmonyPatch(typeof(AscensionMenuScreens), nameof(AscensionMenuScreens.TransitionToGame))]

--- a/InscryptionCommunityPatch/Card/ArtPatches.cs
+++ b/InscryptionCommunityPatch/Card/ArtPatches.cs
@@ -26,8 +26,7 @@ public static class CommunityArtPatches
         Ability.GainGemTriple,
         Ability.Loot,
         Ability.SkeletonStrafe,
-        Ability.SquirrelStrafe,
-        Ability.SubmergeSquid
+        Ability.SquirrelStrafe
     };
 
     internal static readonly List<Ability> gbcIconsToPatch = new() 


### PR DESCRIPTION
This PR does things:

1) It audits the entire card pool on Start(). Specifically, it looks at three common areas where cards get screwed up: abilities, special abilities, and appearance behaviors attached to cards that haven't been properly registered. Or - more likely - a situation where the user created a card but typo'd the GUID/ability ID. Any issues are put into the log file as warnings.

2) It simplifies the process of creating a Special Stat Icon. When you register a Special Stat Icon, it also registers the appropriate Special Triggered Ability at the same time. And when you use the SetStatIcon extension method to set the stat icon for a card, it automatically attaches the ability.