### PR TITLE
stopgap measure for act 2 costs for now

### DIFF
--- a/InscryptionCommunityPatch/Card/Part2CardCostRender.cs
+++ b/InscryptionCommunityPatch/Card/Part2CardCostRender.cs
@@ -12,6 +12,7 @@ public static class Part2CardCostRender
     // This patches the way card costs are rendered in Act 2 (GBC)
 	// It allows mixed card costs to display correctly (i.e., 2 blood, 1 bone)
 	// And makes the card costs take up a smaller amount of space on the card, showing off more art.
+    // Also allows for custom costs to hook in and be displayed without the creator needing to patch cost render
 
     public static event Action<CardInfo, List<Texture2D>> UpdateCardCost;
 
@@ -95,8 +96,8 @@ public static class Part2CardCostRender
 	[HarmonyPrefix]
 	public static bool Part2CardCostDisplayerPatch(ref Sprite __result, ref CardInfo card, ref CardDisplayer __instance)
 	{	
-		//Make sure we are in Leshy's Cabin
-		if (__instance is PixelCardDisplayer) 
+		//Make sure we are only modifying pixel cards
+		if (__instance is PixelCardDisplayer && PatchPlugin.act2CostRender.Value) 
 		{ 
 			/// Set the results as the new sprite
 			__result = Part2SpriteFinal(card);

--- a/InscryptionCommunityPatch/InscryptionCommunityPatchPlugin.cs
+++ b/InscryptionCommunityPatch/InscryptionCommunityPatchPlugin.cs
@@ -1,4 +1,4 @@
-﻿global using UnityObject = UnityEngine.Object;
+global using UnityObject = UnityEngine.Object;
 
 using BepInEx;
 using BepInEx.Configuration;
@@ -30,6 +30,7 @@ public class PatchPlugin : BaseUnityPlugin
     internal static ConfigEntry<bool> configDroneMox;
 
     internal static ConfigEntry<bool> rightAct2Cost;
+    internal static ConfigEntry<bool> act2CostRender;
 
     internal static ConfigEntry<bool> configMergeOnBottom;
 
@@ -66,6 +67,7 @@ public class PatchPlugin : BaseUnityPlugin
         configDrone = Config.Bind("Energy","Energy Drone",false,"Drone is visible to display energy (requires Energy Refresh)");
         configMox = Config.Bind("Mox","Mox Refresh",true,"Mox refreshes at end of battle");
         configDroneMox = Config.Bind("Mox","Mox Drone",false,"Drone displays mox (requires Energy Drone and Mox Refresh)");
+        act2CostRender = Config.Bind("Card Costs", "GBC Cost render", true, "GBC Cards are able to display custom costs and hybrid costs through the API.");
         rightAct2Cost = Config.Bind("Card Costs","GBC Cost On Right",true,"GBC Cards display their costs on the top-right corner. If false, display on the top-left corner");
         configMergeOnBottom = Config.Bind("Sigil Display", "Merge_On_Botom", false, "Makes it so if enabled, merged sigils will display on the bottom of the card instead of on the artwork. In extreme cases, this can cause some visual bugs.");
 		configRemovePatches = Config.Bind("Sigil Display", "Remove_Patches", false, "Makes it so if enabled, merged sigils will not have a patch behind them anymore and will instead be glowing yellow (only works with Merge_On_Bottom).");


### PR DESCRIPTION
Added a config for people who want to opt out of the custom cost and hybrid cost render fix of GBA cards. Not the full version that I wanted to do, but good enough for now while people wait. 