### PR TITLE
feat: Added abosolute path support to `ReadArtworkFileAsBytes`

### DIFF
--- a/InscryptionAPI/Helpers/TextureHelper.cs
+++ b/InscryptionAPI/Helpers/TextureHelper.cs
@@ -58,7 +58,7 @@ public static class TextureHelper
     public static byte[] ReadArtworkFileAsBytes(string pathCardArt)
     {
         return File.ReadAllBytes(
-            Directory.GetFiles(Paths.PluginPath, pathCardArt, SearchOption.AllDirectories)[0]
+            Path.IsPathRooted(pathCardArt) ? pathCardArt : Directory.GetFiles(Paths.PluginPath, pathCardArt, SearchOption.AllDirectories)[0]
         );
     }
 


### PR DESCRIPTION
This pull request aims to fix #62 by checking if `pathCardArt` is rooted or not, If it is rooted, It's abosolute, If it isn't, It's relative.