### PR TITLE
feat: Added "pathTo" overload to Boon and Tribe [...more]

### DIFF
--- a/InscryptionAPI/Boons/BoonBehaviour.cs
+++ b/InscryptionAPI/Boons/BoonBehaviour.cs
@@ -1,8 +1,5 @@
 using DiskCardGame;
-using System;
 using System.Collections;
-using System.Collections.Generic;
-using System.Text;
 
 namespace InscryptionAPI.Boons
 {

--- a/InscryptionAPI/Boons/BoonManager.cs
+++ b/InscryptionAPI/Boons/BoonManager.cs
@@ -1,12 +1,10 @@
 using DiskCardGame;
-using System;
-using System.Collections.Generic;
-using System.Text;
 using UnityEngine;
 using HarmonyLib;
 using System.Collections;
 using System.Collections.ObjectModel;
 using InscryptionAPI.Guid;
+using InscryptionAPI.Helpers;
 
 namespace InscryptionAPI.Boons
 {
@@ -17,7 +15,7 @@ namespace InscryptionAPI.Boons
         public static readonly ObservableCollection<FullBoon> NewBoons = new();
         public static List<BoonData> AllBoonsCopy { get; private set; } = BaseGameBoons.ToList();
 
-        public static BoonData.Type New(string guid, string name, Type boonHandlerType, string rulebookDescription, Texture icon, Texture cardArt, bool stackable = true, bool appearInLeshyTrials = true, bool 
+        public static BoonData.Type New(string guid, string name, Type boonHandlerType, string rulebookDescription, Texture icon, Texture cardArt, bool stackable = true, bool appearInLeshyTrials = true, bool
             appearInRulebook = true)
         {
             FullBoon fb = new();
@@ -41,6 +39,18 @@ namespace InscryptionAPI.Boons
             appearInRulebook = true) where T : BoonBehaviour
         {
             return New(guid, name, typeof(T), rulebookDescription, icon, cardArt, stackable, appearInLeshyTrials, appearInRulebook);
+        }
+
+        public static BoonData.Type New(string guid, string name, Type boonHandlerType, string rulebookDescription, string pathToIcon, string pathToCardArt, bool stackable = true, bool appearInLeshyTrials = true, bool
+            appearInRulebook = true)
+        {
+            return New(guid, name, boonHandlerType, rulebookDescription, TextureHelper.GetImageAsTexture(pathToIcon), TextureHelper.GetImageAsTexture(pathToCardArt), stackable, appearInLeshyTrials, appearInRulebook);
+        }
+
+        public static BoonData.Type New<T>(string guid, string name, string rulebookDescription, string pathToIcon, string pathToCardArt, bool stackable = true, bool appearInLeshyTrials = true, bool
+            appearInRulebook = true) where T : BoonBehaviour
+        {
+            return New<T>(guid, name, rulebookDescription, pathToIcon, pathToCardArt, stackable, appearInLeshyTrials, appearInRulebook);
         }
 
         public static void SyncCardList()

--- a/InscryptionAPI/Boons/DeckInfoExtensions.cs
+++ b/InscryptionAPI/Boons/DeckInfoExtensions.cs
@@ -1,8 +1,4 @@
 using DiskCardGame;
-using System;
-using System.Collections.Generic;
-using System.Text;
-using UnityEngine;
 
 namespace InscryptionAPI.Boons
 {

--- a/InscryptionAPI/Card/TribeManager.cs
+++ b/InscryptionAPI/Card/TribeManager.cs
@@ -1,7 +1,4 @@
 using DiskCardGame;
-using System;
-using System.Collections.Generic;
-using System.Text;
 using UnityEngine;
 using HarmonyLib;
 using InscryptionAPI.Guid;
@@ -99,6 +96,12 @@ namespace InscryptionAPI.Card
             TribeInfo info = new() { tribe = tribe, icon = tribeIcon.ConvertTexture(), cardback = choiceCardbackTexture, tribeChoice = appearInTribeChoices };
             tribes.Add(info);
             return tribe;
+        }
+
+        public static Tribe Add(string guid, string name, string pathToTribeIcon = null, bool appearInTribeChoices = false, string pathToChoiceCardBackTexture = null)
+        {
+            // Reason for 'is not null' is because if we pass 'null' to GetImageAsTexture, It will thorw an exception.
+            return Add(guid, name, pathToTribeIcon is not null ? TextureHelper.GetImageAsTexture(pathToTribeIcon) : null, appearInTribeChoices, pathToChoiceCardBackTexture is not null ? TextureHelper.GetImageAsTexture(pathToChoiceCardBackTexture) : null);
         }
 
         private class TribeInfo


### PR DESCRIPTION
@SpecialAPI seems to forget to add a overload for both manager where user can specify path to the image instead of having to supply Texture instead,

Other manager also have the same overload, CardManager, AbilityManager.

I need review from @divisionbyz0rro and @SpecialAPI.