### PR TITLE
Emissive portrait extensions

### DIFF
--- a/InscryptionAPI/Card/CardExtensions.cs
+++ b/InscryptionAPI/Card/CardExtensions.cs
@@ -694,6 +694,20 @@ public static class CardExtensions
     }
 
     /// <summary>
+    /// Sets the cards portrait and emission at the same time.
+    /// </summary>
+    /// <param name="portrait">The texture containing the card portrait</param>
+    /// <param name="emission">The texture containing the emission</param>
+    /// <param name="filterMode">The filter mode for the texture, or null if no change</param>
+    /// <returns></returns>
+    public static CardInfo SetPortrait(this CardInfo info, Texture2D portrait, Texture2D emission, FilterMode? filterMode = null)
+    {
+        info.SetPortrait(portrait, filterMode);
+        info.SetEmissivePortrait(emission, filterMode);
+        return info;
+    }
+
+    /// <summary>
     /// Sets the default card portrait for the card
     /// </summary>
     /// <param name="info">Card to access</param>

--- a/InscryptionAPI/Helpers/TextureHelper.cs
+++ b/InscryptionAPI/Helpers/TextureHelper.cs
@@ -6,20 +6,65 @@ using System.Reflection;
 
 namespace InscryptionAPI.Helpers;
 
+/// <summary>
+/// This class contains a number of helper methods for managing textures.
+/// </summary>
 [HarmonyPatch]
 public static class TextureHelper
 {
+    /// <summary>
+    /// Thie is used to indicate what type of sprite you wish to create so that the appropriate size and pivot point can be determined.
+    /// </summary>
     public enum SpriteType : int
     {
+        /// <summary>
+        /// A card's portrait art in Act 1 or Act 3
+        /// </summary>
         CardPortrait = 0,
+
+        /// <summary>
+        /// A card's portrait art in Act 2
+        /// </summary>
         PixelPortrait = 1,
+
+        /// <summary>
+        /// An ability icon (sigil) in Act 2 
+        /// </summary>
         PixelAbilityIcon = 2,
+
+        /// <summary>
+        /// A special stat icon in Act 2
+        /// </summary>
         PixelStatIcon = 3,
+
+        /// <summary>
+        /// A challenge skull displayed on the challenge UI during the setup of a Kaycee's Mod run
+        /// </summary>
         ChallengeIcon = 4,
+
+        /// <summary>
+        /// The texture that displays the card's cost in Act 1
+        /// </summary>
         CostDecal = 5,
+
+        /// <summary>
+        /// The large decal used to display multiple/hybrid card costs in Act 1
+        /// </summary>
         OversizedCostDecal = 6,
+
+        /// <summary>
+        /// The decal used to display card costs in Act 2, on the top-left of the card
+        /// </summary>
         Act2CostDecalLeft = 7,
+
+        /// <summary>
+        /// The decal used to display card costs in Act 2, on the top-right of the card
+        /// </summary>
         Act2CostDecalRight = 8,
+
+        /// <summary>
+        /// The starter deck icon displayed on the challenge UI during the setup on a Kaycee's Mod run
+        /// </summary>
         StarterDeckIcon = 9
     };
 
@@ -55,6 +100,11 @@ public static class TextureHelper
         { SpriteType.StarterDeckIcon, new Vector2(0.5f, 0.5f) }
     };
 
+    /// <summary>
+    /// Reads the contents of an image file on disk and returns it as a byte array.
+    /// </summary>
+    /// <param name="pathCardArt">The path to the card on disk. This can be relative to the BepInEx plugin path, or can be an absolute (rooted) path.</param>
+    /// <returns>The contents of the file in pathCardArt as a byte array</returns>
     public static byte[] ReadArtworkFileAsBytes(string pathCardArt)
     {
         if (!Path.IsPathRooted(pathCardArt))
@@ -69,6 +119,12 @@ public static class TextureHelper
         return File.ReadAllBytes(pathCardArt);
     }
 
+    /// <summary>
+    /// Converts an artwork file on disk to a Unity Texture2D object
+    /// </summary>
+    /// <param name="pathCardArt">The path to the card on disk. This can be relative to the BepInEx plugin path, or can be an absolute (rooted) path.</param>
+    /// <param name="filterMode">Sets the filter mode of the art. Leave this alone unless you know why you're changing it.</param>
+    /// <returns>The image file on disk as a Texture2D object</returns>
     public static Texture2D GetImageAsTexture(string pathCardArt, FilterMode filterMode = FilterMode.Point)
     {
         Texture2D texture = new Texture2D(2, 2,TextureFormat.RGBA32,false);
@@ -78,6 +134,13 @@ public static class TextureHelper
         return texture;
     }
 
+    /// <summary>
+    /// Converts an artwork file stored as a resource in an assembly file to a Unity Texture2D object
+    /// </summary>
+    /// <param name="pathCardArt">The name of the artwork file in the assembly</param>
+    /// <param name="target">The assembly to pull the artwork file from</param>
+    /// <param name="filterMode">Sets the filter mode of the art. Leave this alone unless you know why you're changing it.</param>
+    /// <returns>The image file from the assembly as a Texture2D object</returns>
     public static Texture2D GetImageAsTexture(string pathCardArt, Assembly target, FilterMode filterMode = FilterMode.Point)
     {
         Texture2D texture = new Texture2D(2, 2,TextureFormat.RGBA32,false);
@@ -87,6 +150,13 @@ public static class TextureHelper
         return texture;
     }
 
+    /// <summary>
+    /// Converts a Unity Texture2D object to a Sprite that conforms to the expectations for the given sprite type
+    /// </summary>
+    /// <param name="texture">The Texture2D object to convert</param>
+    /// <param name="spriteType">The type of sprite to create</param>
+    /// <param name="filterMode">Sets the filter mode of the art. Leave this alone unless you know why you're changing it.</param>
+    /// <returns>A sprite containing the given texture</returns>
     public static Sprite ConvertTexture(this Texture2D texture, SpriteType spriteType, FilterMode filterMode = FilterMode.Point)
     {
         texture.filterMode = filterMode;
@@ -94,47 +164,82 @@ public static class TextureHelper
         return retval;
     }
 
+    /// <summary>
+    /// Converts a Unity Texture2D object to a Sprite with the same dimensions as the texture
+    /// </summary>
+    /// <param name="texture">The Texture2D object to convert</param>
+    /// <param name="pivot">The pivot of the sprite. If null/default, the pivot will be the middle of the texture.</param>
+    /// <returns>A sprite containing the given texture</returns>
     public static Sprite ConvertTexture(this Texture2D texture, Vector2? pivot = null)
     {
         pivot ??= new Vector2(0.5f, 0.5f);
         return Sprite.Create(texture, new Rect(0f, 0f, texture.width, texture.height), pivot.Value);
     }
 
+    /// <summary>
+    /// Converts an image on disk to a Sprite that conforms to the expectations for the given sprite type
+    /// </summary>
+    /// <param name="pathCardArt">The path to the card on disk. This can be relative to the BepInEx plugin path, or can be an absolute (rooted) path.</param>
+    /// <param name="spriteType">The type of sprite to create</param>
+    /// <param name="filterMode">Sets the filter mode of the art. Leave this alone unless you know why you're changing it.</param>
+    /// <returns>A sprite containing the image file on disk</returns>
     public static Sprite GetImageAsSprite(string pathCardArt, SpriteType spriteType, FilterMode filterMode = FilterMode.Point)
     {
         return GetImageAsTexture(pathCardArt).ConvertTexture(spriteType, filterMode);
     }
 
+    /// <summary>
+    /// Sets the emissive sprite for a given sprite. This is used when an Act 1 card receives an ability from a card merge.
+    /// </summary>
+    /// <param name="regularSprite">The normal sprite</param>
+    /// <param name="emissionSprite">The emissive sprite</param>
     public static void RegisterEmissionForSprite(this Sprite regularSprite, Sprite emissionSprite)
     {
         emissionSprite.name = regularSprite.name + "_emission";
-        emissionMap.Add(regularSprite, emissionSprite);
+        emissionMap[regularSprite] = emissionSprite;
     }
 
+    /// <summary>
+    /// Sets the emissive sprite for a given sprite. This is used when an Act 1 card receives an ability from a card merge.
+    /// </summary>
+    /// <param name="regularSprite">The normal sprite</param>
+    /// <param name="emissionSprite">The emissive sprite</param>
     public static void RegisterEmissionForSprite(this Sprite regularSprite, Texture2D texture, SpriteType spriteType, FilterMode filterMode = FilterMode.Point)
     {
         Sprite emissionSprite = texture.ConvertTexture(spriteType, filterMode);
         emissionSprite.name = regularSprite.name + "_emission";
-        emissionMap.Add(regularSprite, emissionSprite);
+        emissionMap[regularSprite] = emissionSprite;
     }
 
+    /// <summary>
+    /// Sets the emissive sprite for a given sprite. This is used when an Act 1 card receives an ability from a card merge.
+    /// </summary>
+    /// <param name="regularSprite">The normal sprite</param>
+    /// <param name="texture">The Texture2D object to convert to the emissive sprite</param>
+    /// <param name="spriteType">The type of sprite to create</param>
+    /// <param name="filterMode">Sets the filter mode of the art. Leave this alone unless you know why you're changing it.</param>
     public static void RegisterEmissionForSprite(this Sprite regularSprite, string pathToArt, SpriteType spriteType, FilterMode filterMode = FilterMode.Point)
     {
         Sprite emissionSprite = GetImageAsSprite(pathToArt, spriteType, filterMode);
         emissionSprite.name = regularSprite.name + "_emission";
-        emissionMap.Add(regularSprite, emissionSprite);
+        emissionMap[regularSprite] = emissionSprite;
     }
 
+    /// <summary>
+    /// Sets the emissive portrait for the card's alternate portrait using the same emission as the default portrait
+    /// </summary>
+    /// <param name="info">The card to set the emission for</param>
+    /// <param name="alternatePortrait">The alternate portrait for the card</param>
     public static void TryReuseEmission(CardInfo info, Sprite alternatePortrait)
     {
         if (info.portraitTex != null)
-            if (emissionMap.ContainsKey(info.portraitTex))
-                emissionMap.Add(alternatePortrait, emissionMap[info.portraitTex]);
+            if (emissionMap.ContainsKey(info.portraitTex) && !emissionMap.ContainsKey(alternatePortrait))
+                emissionMap[alternatePortrait] = emissionMap[info.portraitTex];
     }
 
     [HarmonyPatch(typeof(CardDisplayer3D), nameof(CardDisplayer3D.GetEmissivePortrait))]
     [HarmonyPrefix]
-    public static bool GetCustomEmission(Sprite mainPortrait, ref Sprite __result)
+    private static bool GetCustomEmission(Sprite mainPortrait, ref Sprite __result)
     {
         if (emissionMap.ContainsKey(mainPortrait))
         {
@@ -144,6 +249,12 @@ public static class TextureHelper
         return true;
     }
 
+    /// <summary>
+    /// Reads the contents of an image file in an assembly and returns it as a byte array.
+    /// </summary>
+    /// <param name="pathCardArt">The name of the art file stored as a resource in the assembly</param>
+    /// <param name="target">The assembly to pull the art from</param>
+    /// <returns>The contents of the file in pathCardArt as a byte array</returns>
     public static byte[] GetResourceBytes(string filename, Assembly target)
     {
         string lowerKey = $".{filename.ToLowerInvariant()}";
@@ -162,6 +273,24 @@ public static class TextureHelper
         }
     }
 
+    /// <summary>
+    /// Combines multiple textures into one, using a tiled approach.
+    /// </summary>
+    /// <remarks>
+    /// This helper has a very specific purpose. The pixels in <paramref>baseTexture</paramref> will be iteratively replaced with the pixels
+    /// in the <paramref>pieces</paramref> array. The X position for the i-th texture will be 
+    /// <paramref>xOffset</paramref> + <paramref>xStep</paramref> * i. The Y position for the i-th texture will be
+    /// <paramref>yOffset</paramref> + <paramref>yStep</paramref> * (<paramref>pieces</paramref>.Count - i - 1).
+    /// 
+    /// **Note**: <paramref>baseTexture</paramref> will be modified in-place!
+    /// </remarks>
+    /// <param name="pieces">The individual textures to combine into the base texture</param>
+    /// <param name="baseTexture">The background texture for the combined texture</param>
+    /// <param name="xStep">Used to set the position for individual textures</param>
+    /// <param name="yStep">Used to set the position for individual textures</param>
+    /// <param name="xOffset">Used to set the position for individual textures</param>
+    /// <param name="yOffset">Used to set the position for individual textures</param>
+    /// <returns>The modified texture (the same Texture references as <paramref>baseTexture</paramref></returns>
     public static Texture2D CombineTextures(List<Texture2D> pieces, Texture2D baseTexture, int xStep = 0, int yStep = 0, int xOffset = 0, int yOffset = 0)
 	{
 		if (pieces != null)


### PR DESCRIPTION
This PR adds back an extension method that was mistakenly lost in the latest changes to the card extension methods.

This also fixes [this issue](https://github.com/InscryptionModding/InscryptionAPI/issues/67).

And adds XML documentation to TextureHelper