### PR TITLE
feat: Added `object` support to the save file. [...more]

### DIFF
--- a/InscryptionAPI/Guid/GuidManager.cs
+++ b/InscryptionAPI/Guid/GuidManager.cs
@@ -34,7 +34,7 @@ public static class GuidManager
         {
             if (item.Key.StartsWith(startKey))
             {
-                int enumVal = int.Parse(item.Value);
+                int enumVal = int.Parse((string) item.Value);
                 T convertedEnumVal = *(T*)&enumVal;
                 itemList.Add(convertedEnumVal);
             }

--- a/InscryptionAPI/Guid/GuidManager.cs
+++ b/InscryptionAPI/Guid/GuidManager.cs
@@ -34,7 +34,7 @@ public static class GuidManager
         {
             if (item.Key.StartsWith(startKey))
             {
-                int enumVal = int.Parse((string) item.Value);
+                int enumVal = int.Parse((string)item.Value);
                 T convertedEnumVal = *(T*)&enumVal;
                 itemList.Add(convertedEnumVal);
             }
@@ -56,11 +56,11 @@ public static class GuidManager
         {
             lock (lockObject)
             {
-                enumValue = ModdedSaveManager.SaveData.GetValueAsInt(InscryptionAPIPlugin.ModGUID, MAX_DATA) + 1;
+                enumValue = ModdedSaveManager.SaveData.GetValueAsInt(InscryptionAPIPlugin.ModGUID, MAX_DATA);
                 if (enumValue < START_INDEX)
                     enumValue = START_INDEX;
                 
-                ModdedSaveManager.SaveData.SetValue(InscryptionAPIPlugin.ModGUID, MAX_DATA, enumValue);
+                ModdedSaveManager.SaveData.SetValue(InscryptionAPIPlugin.ModGUID, MAX_DATA, enumValue+1);
                 ModdedSaveManager.SaveData.SetValue(InscryptionAPIPlugin.ModGUID, saveKey, enumValue);
 
                 ModdedSaveManager.isSystemDirty = true;

--- a/InscryptionAPI/Saves/ModdedSaveData.cs
+++ b/InscryptionAPI/Saves/ModdedSaveData.cs
@@ -5,17 +5,6 @@ public class ModdedSaveData
     internal Dictionary<string, Dictionary<string, object>> SaveData = new();
 
     /// <summary>
-    /// Get the value of a key as a string in the save data.
-    /// </summary>
-    /// <param name="guid">The GUID of the mod.</param>
-    /// <param name="key">The key to get the value of.</param>
-    /// <returns>The value of the key as a string.</returns>
-    public string GetValue(string guid, string key)
-    {
-        return GetValueAsObject<string>(guid, key);
-    }
-
-    /// <summary>
     /// Get the value of a key as an object in the save data.
     /// </summary>
     /// <param name="guid">The GUID of the mod.</param>
@@ -33,6 +22,18 @@ public class ModdedSaveData
             SaveData[guid].Add(key, null);
 
         return (T)SaveData[guid][key];
+    }
+
+    /// <summary>
+    /// Get the value of a key as a string in the save data.
+    /// </summary>
+    /// <param name="guid">The GUID of the mod.</param>
+    /// <param name="key">The key to get the value of.</param>
+    /// <returns>The value of the key as a string.</returns>
+    public string GetValue(string guid, string key)
+    {
+        var value = GetValueAsObject<object>(guid, key);
+        return value == null ? default(string) : value.ToString();
     }
 
     /// <summary>
@@ -78,12 +79,12 @@ public class ModdedSaveData
     }
 
     /// <summary>
-    /// Set the value of a key in the save data.
+    /// Set the value of a key as an object in the save data.
     /// </summary>
     /// <param name="guid">The GUID of the mod.</param>
     /// <param name="key">The key to set the value of.</param>
-    /// <param name="value">The value to set.</param>
-    public void SetValue(string guid, string key, object value)
+    /// <param name="value">The object value to set.</param>
+    public void SetValueAsObject(string guid, string key, object value)
     {
         if (!SaveData.ContainsKey(guid))
             SaveData.Add(guid, new());
@@ -92,5 +93,16 @@ public class ModdedSaveData
             SaveData[guid].Add(key, value);
         else
             SaveData[guid][key] = value;
+    }
+
+    /// <summary>
+    /// Set the value of a key in the save data.
+    /// </summary>
+    /// <param name="guid">The GUID of the mod.</param>
+    /// <param name="key">The key to set the value of.</param>
+    /// <param name="value">The value to set.</param>
+    public void SetValue(string guid, string key, object value)
+    {
+        SetValueAsObject(guid, key, value == null ? default(string) : value.ToString());
     }
 }

--- a/InscryptionAPI/Saves/ModdedSaveData.cs
+++ b/InscryptionAPI/Saves/ModdedSaveData.cs
@@ -79,7 +79,8 @@ public class ModdedSaveData
     }
 
     /// <summary>
-    /// Set the value of a key as an object in the save data.
+    /// Set the value of a key as an object in the save data,
+    /// It's recommended to not save an object that implements Unity's Object class as it can cause a infinite recursion and crash the game.
     /// </summary>
     /// <param name="guid">The GUID of the mod.</param>
     /// <param name="key">The key to set the value of.</param>

--- a/InscryptionAPI/Saves/ModdedSaveData.cs
+++ b/InscryptionAPI/Saves/ModdedSaveData.cs
@@ -10,7 +10,7 @@ public class ModdedSaveData
     /// <param name="guid">The GUID of the mod.</param>
     /// <param name="key">The key to get the value of.</param>
     /// <returns>The value of the key as an object.</returns>
-    /// <typeparam name="T">The type of object.</typeparam>
+    /// <typeparam name="T">The type of object you are getting.</typeparam>
     public T GetValueAsObject<T>(string guid, string key)
     {
         if (SaveData == null)

--- a/InscryptionAPI/Saves/ModdedSaveData.cs
+++ b/InscryptionAPI/Saves/ModdedSaveData.cs
@@ -2,9 +2,26 @@ namespace InscryptionAPI.Saves;
 
 public class ModdedSaveData
 {
-    internal Dictionary<string, Dictionary<string, string>> SaveData = new();
+    internal Dictionary<string, Dictionary<string, object>> SaveData = new();
 
+    /// <summary>
+    /// Get the value of a key as a string in the save data.
+    /// </summary>
+    /// <param name="guid">The GUID of the mod.</param>
+    /// <param name="key">The key to get the value of.</param>
+    /// <returns>The value of the key as a string.</returns>
     public string GetValue(string guid, string key)
+    {
+        return GetValueAsObject<string>(guid, key);
+    }
+
+    /// <summary>
+    /// Get the value of a key as an object in the save data.
+    /// </summary>
+    /// <param name="guid">The GUID of the mod.</param>
+    /// <param name="key">The key to get the value of.</param>
+    /// <returns>The value of the key as an object.</returns>
+    public T GetValueAsObject<T>(string guid, string key)
     {
         if (SaveData == null)
             SaveData = new();
@@ -13,11 +30,17 @@ public class ModdedSaveData
             SaveData.Add(guid, new());
 
         if (!SaveData[guid].ContainsKey(key))
-            SaveData[guid].Add(key, default(string));
+            SaveData[guid].Add(key, null);
 
-        return SaveData[guid][key];
+        return (T)SaveData[guid][key];
     }
 
+    /// <summary>
+    /// Get the value of a key as an integer in the save data.
+    /// </summary>
+    /// <param name="guid">The GUID of the mod.</param>
+    /// <param name="key">The key to get the value of.</param>
+    /// <returns>The value of the key as an integer.</returns>
     public int GetValueAsInt(string guid, string key)
     {
         string value = GetValue(guid, key);
@@ -26,6 +49,12 @@ public class ModdedSaveData
         return result;
     }
 
+    /// <summary>
+    /// Get the value of a key as a float in the save data.
+    /// </summary>
+    /// <param name="guid">The GUID of the mod.</param>
+    /// <param name="key">The key to get the value of.</param>
+    /// <returns>The value of the key as a float.</returns>
     public float GetValueAsFloat(string guid, string key)
     {
         string value = GetValue(guid, key);
@@ -34,6 +63,12 @@ public class ModdedSaveData
         return result;
     }
 
+    /// <summary>
+    /// Get the value of a key as a boolean in the save data.
+    /// </summary>
+    /// <param name="guid">The GUID of the mod.</param>
+    /// <param name="key">The key to get the value of.</param>
+    /// <returns>The value of the key as a boolean.</returns>
     public bool GetValueAsBoolean(string guid, string key)
     {
         string value = GetValue(guid, key);
@@ -42,16 +77,20 @@ public class ModdedSaveData
         return result;
     }
 
+    /// <summary>
+    /// Set the value of a key in the save data.
+    /// </summary>
+    /// <param name="guid">The GUID of the mod.</param>
+    /// <param name="key">The key to set the value of.</param>
+    /// <param name="value">The value to set.</param>
     public void SetValue(string guid, string key, object value)
     {
         if (!SaveData.ContainsKey(guid))
             SaveData.Add(guid, new());
 
-        string valueString = value == null ? default(string) : value.ToString();
-
         if (!SaveData[guid].ContainsKey(key))
-            SaveData[guid].Add(key, valueString);
+            SaveData[guid].Add(key, value);
         else
-            SaveData[guid][key] = valueString;
+            SaveData[guid][key] = value;
     }
 }

--- a/InscryptionAPI/Saves/ModdedSaveData.cs
+++ b/InscryptionAPI/Saves/ModdedSaveData.cs
@@ -10,6 +10,7 @@ public class ModdedSaveData
     /// <param name="guid">The GUID of the mod.</param>
     /// <param name="key">The key to get the value of.</param>
     /// <returns>The value of the key as an object.</returns>
+    /// <typeparam name="T">The type of object.</typeparam>
     public T GetValueAsObject<T>(string guid, string key)
     {
         if (SaveData == null)
@@ -85,7 +86,8 @@ public class ModdedSaveData
     /// <param name="guid">The GUID of the mod.</param>
     /// <param name="key">The key to set the value of.</param>
     /// <param name="value">The object value to set.</param>
-    public void SetValueAsObject(string guid, string key, object value)
+    /// <typeparam name="T">The type of object you are setting.</typeparam>
+    public void SetValueAsObject<T>(string guid, string key, T value)
     {
         if (!SaveData.ContainsKey(guid))
             SaveData.Add(guid, new());

--- a/InscryptionAPI/Saves/ModdedSaveManager.cs
+++ b/InscryptionAPI/Saves/ModdedSaveManager.cs
@@ -51,7 +51,7 @@ public static class ModdedSaveManager
 
         var oldSaveFileExist = File.Exists(oldSaveFilePath);
 
-        // If old save file exists, move it to new save file location
+        // If old save file exists, Use the old save file.
         if (File.Exists(saveFilePath) || oldSaveFileExist)
         {
             string json = oldSaveFileExist ? File.ReadAllText(oldSaveFilePath) : File.ReadAllText(saveFilePath);

--- a/InscryptionAPI/Saves/ModdedSaveManager.cs
+++ b/InscryptionAPI/Saves/ModdedSaveManager.cs
@@ -11,14 +11,16 @@ public static class ModdedSaveManager
 
     private static readonly string saveFilePath = Path.Combine(BepInEx.Paths.GameRootPath, "ModdedSaveFile.gwsave");
 
+    private static readonly string backupSaveFilePath = Path.Combine(BepInEx.Paths.GameRootPath, "ModdedSaveFile-Backup.gwsave");
+
 
     /// <summary>
-    /// Get the current SaveData from the modded save file.
+    /// Current modded SaveData.
     /// </summary>
     public static ModdedSaveData SaveData { get; private set; }
 
     /// <summary>
-    /// Get the current RunState from the modded save file.
+    /// Current modded RunState.
     /// </summary>
     public static ModdedSaveData RunState { get; private set; }
 
@@ -38,6 +40,7 @@ public static class ModdedSaveManager
         var saveData = (SaveData.SaveData, RunState.SaveData);
         string moddedSaveData = SaveManager.ToJSON(saveData);
         File.WriteAllText(saveFilePath, moddedSaveData);
+        File.Copy(saveFilePath, backupSaveFilePath, true);
     }
 
     [HarmonyPatch(typeof(SaveManager), "LoadFromFile")]
@@ -58,7 +61,7 @@ public static class ModdedSaveManager
             if (oldSaveFileExist) File.Move(oldSaveFilePath, saveFilePath);
 
             string json = File.ReadAllText(saveFilePath);
-            var saveData = SaveManager.FromJSON<(Dictionary<string, Dictionary<string, string>>, Dictionary<string, Dictionary<string, string>>)>(json);
+            var saveData = SaveManager.FromJSON<(Dictionary<string, Dictionary<string, object>>, Dictionary<string, Dictionary<string, object>>)>(json);
 
             if (SaveData == null)
                 SaveData = new();

--- a/InscryptionAPI/Saves/ModdedSaveManager.cs
+++ b/InscryptionAPI/Saves/ModdedSaveManager.cs
@@ -54,9 +54,7 @@ public static class ModdedSaveManager
         // If old save file exists, move it to new save file location
         if (File.Exists(saveFilePath) || oldSaveFileExist)
         {
-            if (oldSaveFileExist) File.Move(oldSaveFilePath, saveFilePath);
-
-            string json = File.ReadAllText(saveFilePath);
+            string json = oldSaveFileExist ? File.ReadAllText(oldSaveFilePath) : File.ReadAllText(saveFilePath);
             var saveData = SaveManager.FromJSON<(Dictionary<string, Dictionary<string, object>>, Dictionary<string, Dictionary<string, object>>)>(json);
 
             if (SaveData == null)

--- a/InscryptionAPI/Saves/ModdedSaveManager.cs
+++ b/InscryptionAPI/Saves/ModdedSaveManager.cs
@@ -52,7 +52,7 @@ public static class ModdedSaveManager
         var oldSaveFileExist = File.Exists(oldSaveFilePath);
         var newSaveFileExist = File.Exists(saveFilePath);
 
-        // If old save file exists, move it to new save file location
+        // If both old and new file exists, Delete the new one and move the old one to new path
         if (newSaveFileExist || oldSaveFileExist)
         {
             if (newSaveFileExist && oldSaveFileExist) File.Delete(saveFilePath);

--- a/InscryptionAPI/Saves/ModdedSaveManager.cs
+++ b/InscryptionAPI/Saves/ModdedSaveManager.cs
@@ -11,9 +11,6 @@ public static class ModdedSaveManager
 
     private static readonly string saveFilePath = Path.Combine(BepInEx.Paths.GameRootPath, "ModdedSaveFile.gwsave");
 
-    private static readonly string backupSaveFilePath = Path.Combine(BepInEx.Paths.GameRootPath, "ModdedSaveFile-Backup.gwsave");
-
-
     /// <summary>
     /// Current modded SaveData.
     /// </summary>
@@ -40,7 +37,6 @@ public static class ModdedSaveManager
         var saveData = (SaveData.SaveData, RunState.SaveData);
         string moddedSaveData = SaveManager.ToJSON(saveData);
         File.WriteAllText(saveFilePath, moddedSaveData);
-        File.Copy(saveFilePath, backupSaveFilePath, true);
     }
 
     [HarmonyPatch(typeof(SaveManager), "LoadFromFile")]

--- a/InscryptionAPI/Saves/ModdedSaveManager.cs
+++ b/InscryptionAPI/Saves/ModdedSaveManager.cs
@@ -25,14 +25,8 @@ public static class ModdedSaveManager
     // This only happens during initialization
     // We use it to make sure that loading data doesn't overwrite system data.
 
-    /// <summary>
-    /// If we are using the old save file path, this will return true.
-    /// </summary>
-    public static bool isOldPath = false;
-
     static ModdedSaveManager()
     {
-        isOldPath = File.Exists(oldSaveFilePath);
         ReadDataFromFile();
     }
 
@@ -42,7 +36,7 @@ public static class ModdedSaveManager
     {
         var saveData = (SaveData.SaveData, RunState.SaveData);
         string moddedSaveData = SaveManager.ToJSON(saveData);
-        File.WriteAllText(isOldPath ? oldSaveFilePath : saveFilePath, moddedSaveData);
+        File.WriteAllText(saveFilePath, moddedSaveData);
     }
 
     [HarmonyPatch(typeof(SaveManager), "LoadFromFile")]
@@ -55,10 +49,15 @@ public static class ModdedSaveManager
             isSystemDirty = false;
         }
 
-        // If old save file exists, Use the old save file.
-        if (File.Exists(saveFilePath) || isOldPath)
+        var oldSaveFileExist = File.Exists(oldSaveFilePath);
+        var newSaveFileExist = File.Exists(saveFilePath);
+
+        // If old save file exists, move it to new save file location
+        if (newSaveFileExist || oldSaveFileExist)
         {
-            string json = isOldPath ? File.ReadAllText(oldSaveFilePath) : File.ReadAllText(saveFilePath);
+            if (newSaveFileExist && oldSaveFileExist) File.Delete(saveFilePath);
+            if (oldSaveFileExist) File.Move(oldSaveFilePath, saveFilePath);
+            string json = File.ReadAllText(saveFilePath);
             var saveData = SaveManager.FromJSON<(Dictionary<string, Dictionary<string, object>>, Dictionary<string, Dictionary<string, object>>)>(json);
 
             if (SaveData == null)

--- a/docs/namespace/InscryptionAPI.Saves.md
+++ b/docs/namespace/InscryptionAPI.Saves.md
@@ -2,4 +2,4 @@
 uid: InscryptionAPI.Saves
 summary: *content
 ---
-This is an example to override namespace.
+This namespace is dedicated to management of save file (Especially modded save file).


### PR DESCRIPTION
change: Changed the save file folder to be the same as the base one.
docs: Added documentation to `InscryptionAPI.Save` namespace, as well as the save file's methods.

- Why put the modded save file in the same folder as the base one?
- When someone need delete their corrupted save file, they don't have to navigate to two folders, and due to the nature of r2mm, It can sometimes be in different drive too.

- Why add object support to the save file?
- Organization, Less function call, For Example
```cs
var GUID = "this.is.an.example"
ModdedSaveManager.SaveData.GetValue(GUID, "player_progress_map");
ModdedSaveManager.SaveData.GetValue(GUID, "player_progress_tries");
ModdedSaveManager.SaveData.GetValue(GUID, "player_progress_brah");
ModdedSaveManager.SaveData.GetValue(GUID, "player_progress_wow");
```
With the support, we can just
```cs
public class PlayerProgress {
    public static string Map { get; set; }
    public static string Tries { get; set; }
    public static string Brah { get; set; }
    public static string Wow { get; set; }
}

var GUID = "this.is.an.example"
ModdedSaveManager.SaveData.GetValueAsObject<PlayerProgress>(GUID, "player_progress");
```