### PR TITLE
Re-added ExtendedAbilityBehaviour

### DIFF
--- a/InscryptionAPI/Boons/BoonManager.cs
+++ b/InscryptionAPI/Boons/BoonManager.cs
@@ -175,6 +175,10 @@ namespace InscryptionAPI.Boons
                     if (boon != null)
                     {
                         FullBoon nb = NewBoons.ToList().Find((x) => x.boon.type == boon.type);
+
+                        if (nb == null)
+                            continue;
+
                         int instances = BoonBehaviour.CountInstancesOfType(nb.boon.type);
                         if (nb != null && nb.boonHandlerType != null && nb.boonHandlerType.IsSubclassOf(typeof(BoonBehaviour)) && (nb.stacks || instances < 1))
                         {

--- a/InscryptionAPI/Card/ExtendedAbilityBehaviour.cs
+++ b/InscryptionAPI/Card/ExtendedAbilityBehaviour.cs
@@ -1,0 +1,138 @@
+using System.Runtime.CompilerServices;
+using DiskCardGame;
+using HarmonyLib;
+using InscryptionAPI.Triggers;
+
+namespace InscryptionAPI.Card;
+
+[HarmonyPatch]
+public abstract class ExtendedAbilityBehaviour : AbilityBehaviour, IGetOpposingSlots, IActivateWhenFacedown, IPassiveAttackBuff, IPassiveHealthBuff
+{
+    // This section handles attack slot management
+
+    public virtual bool TriggerWhenFacedown => false;
+    public virtual bool ShouldTriggerWhenFaceDown(Trigger trigger, object[] otherArgs) => TriggerWhenFacedown;
+    public virtual bool ShouldTriggerCustomWhenFaceDown(Type customTrigger) => TriggerWhenFacedown;
+
+    public virtual bool RespondsToGetOpposingSlots() => false;
+
+    public virtual List<CardSlot> GetOpposingSlots(List<CardSlot> originalSlots, List<CardSlot> otherAddedSlots) => new();
+
+    public virtual bool RemoveDefaultAttackSlot() => false;
+
+    [HarmonyPatch(typeof(PlayableCard), nameof(PlayableCard.GetOpposingSlots))]
+    [HarmonyPostfix]
+    private static void UpdateOpposingSlots(ref PlayableCard __instance, ref List<CardSlot> __result)
+    {
+        bool isAttackingDefaultSlot = !__instance.HasTriStrike() && !__instance.HasAbility(Ability.SplitStrike);
+        CardSlot defaultslot = __instance.Slot.opposingSlot;
+
+        List<CardSlot> alteredOpposings = new List<CardSlot>();
+        bool removeDefaultAttackSlot = false;
+
+        foreach (IGetOpposingSlots component in CustomTriggerFinder.FindTriggersOnCard<IGetOpposingSlots>(__instance))
+        {
+            alteredOpposings.AddRange(component.GetOpposingSlots(__result, new(alteredOpposings)));
+            removeDefaultAttackSlot = removeDefaultAttackSlot || component.RemoveDefaultAttackSlot();  
+        }
+        
+        if (alteredOpposings.Count > 0) 
+            __result.AddRange(alteredOpposings);
+
+        if (isAttackingDefaultSlot && removeDefaultAttackSlot)
+            __result.Remove(defaultslot);
+    }
+
+    // This section handles passive attack/health buffs
+
+    private static ConditionalWeakTable<PlayableCard, List<ExtendedAbilityBehaviour>> AttackBuffAbilities = new();
+    private static ConditionalWeakTable<PlayableCard, List<ExtendedAbilityBehaviour>> HealthBuffAbilities = new();
+
+    private static List<ExtendedAbilityBehaviour> GetAttackBuffs(PlayableCard card)
+    {
+        List<ExtendedAbilityBehaviour> retval;
+        if (AttackBuffAbilities.TryGetValue(card, out retval))
+            return retval;
+
+        retval = card.GetComponents<ExtendedAbilityBehaviour>().Where(x => x.ProvidesPassiveAttackBuff).ToList();
+        AttackBuffAbilities.Add(card, retval);
+        return retval;
+    }
+
+    private static List<ExtendedAbilityBehaviour> GetHealthBuffs(PlayableCard card)
+    {
+        List<ExtendedAbilityBehaviour> retval;
+        if (HealthBuffAbilities.TryGetValue(card, out retval))
+            return retval;
+
+        retval = card.GetComponents<ExtendedAbilityBehaviour>().Where(x => x.ProvidesPassiveHealthBuff).ToList();
+        HealthBuffAbilities.Add(card, retval);
+        return retval;
+    }
+
+    [Obsolete("Use IPassiveAttackBuff instead")]
+    public virtual bool ProvidesPassiveAttackBuff => false;
+
+    [Obsolete("Use IPassiveHealthBuff instead")]
+    public virtual bool ProvidesPassiveHealthBuff => false;
+
+    [Obsolete("Use IPassiveAttackBuff instead")]
+    public virtual int[] GetPassiveAttackBuffs() => null;
+
+    [Obsolete("Use IPassiveHealthBuff instead")]
+    public virtual int[] GetPassiveHealthBuffs() => null;
+
+    [HarmonyPatch(typeof(PlayableCard), nameof(PlayableCard.GetPassiveAttackBuffs))]
+    [HarmonyPostfix]
+    private static void AddPassiveAttackBuffs(ref PlayableCard __instance, ref int __result)
+    {
+        if (__instance.slot == null)
+            return;
+
+        foreach (IPassiveAttackBuff buffer in BoardManager.Instance.CardsOnBoard.SelectMany(c => CustomTriggerFinder.FindTriggersOnCard<IPassiveAttackBuff>(c)))
+            __result += buffer.GetPassiveAttackBuff(__instance);
+    }
+
+    [HarmonyPatch(typeof(PlayableCard), nameof(PlayableCard.GetPassiveHealthBuffs))]
+    [HarmonyPostfix]
+    private static void AddPassiveHealthBuffs(ref PlayableCard __instance, ref int __result)
+    {
+        if (__instance.slot == null)
+            return;
+
+        foreach (IPassiveHealthBuff buffer in BoardManager.Instance.CardsOnBoard.SelectMany(c => CustomTriggerFinder.FindTriggersOnCard<IPassiveHealthBuff>(c)))
+            __result += buffer.GetPassiveHealthBuff(__instance);
+    }
+
+    public virtual int GetPassiveAttackBuff(PlayableCard target)
+    {
+        if (ProvidesPassiveAttackBuff)
+        {
+            if (target.OpponentCard == this.Card.OpponentCard)
+            {
+                int[] result = GetPassiveAttackBuffs();
+                if (result != null && target.Slot.Index < result.Length)
+                {
+                    return result[target.Slot.Index];
+                }
+            }
+        }
+        return 0;
+    }
+
+    public virtual int GetPassiveHealthBuff(PlayableCard target)
+    {
+        if (ProvidesPassiveHealthBuff)
+        {
+            if (target.OpponentCard == this.Card.OpponentCard)
+            {
+                int[] result = GetPassiveHealthBuffs();
+                if (result != null && target.Slot.Index < result.Length)
+                {
+                    return result[target.Slot.Index];
+                }
+            }
+        }
+        return 0;
+    }
+}

--- a/InscryptionAPI/Card/ExtendedAbilityBehaviour.cs
+++ b/InscryptionAPI/Card/ExtendedAbilityBehaviour.cs
@@ -32,8 +32,11 @@ public abstract class ExtendedAbilityBehaviour : AbilityBehaviour, IGetOpposingS
 
         foreach (IGetOpposingSlots component in CustomTriggerFinder.FindTriggersOnCard<IGetOpposingSlots>(__instance))
         {
-            alteredOpposings.AddRange(component.GetOpposingSlots(__result, new(alteredOpposings)));
-            removeDefaultAttackSlot = removeDefaultAttackSlot || component.RemoveDefaultAttackSlot();  
+            if (component.RespondsToGetOpposingSlots())
+            {
+                alteredOpposings.AddRange(component.GetOpposingSlots(__result, new(alteredOpposings)));
+                removeDefaultAttackSlot = removeDefaultAttackSlot || component.RemoveDefaultAttackSlot();  
+            }
         }
         
         if (alteredOpposings.Count > 0) 

--- a/InscryptionAPI/Triggers/Interfaces.cs
+++ b/InscryptionAPI/Triggers/Interfaces.cs
@@ -183,3 +183,58 @@ public interface IOtherCardDealtDamageInHand
     /// <param name="defender">The defender</param>
     IEnumerator OnOtherCardDealtDamageInHand(PlayableCard attacker, int attack, PlayableCard defender);
 }
+
+/// <summary>
+/// Run whenever a card is asked what its opposing slots are as part of the attack sequence
+/// </summary>
+public interface IGetOpposingSlots
+{
+    /// <summary>
+    /// Indicates if this card wants to respond to getting the opposing slots
+    /// </summary>
+    /// <returns>True to provide opposing slots, False to leave the slots as default</returns>
+    bool RespondsToGetOpposingSlots();
+
+    /// <summary>
+    /// Gets the card slots that the card wants to attack
+    /// </summary>
+    /// <param name="originalSlots">The set of original card slots that the card would attack (as set by abilities in the base game)</param>
+    /// <param name="otherAddedSlots">Slots that have been added by other custom abilities</param>
+    /// <returns>The list of card slots you want to attack</returns>
+    /// <remarks>If your card is replacing the default attack slot (the opposing slot) see 'RemoveDefaultAttackSlot'
+    /// If you are **not** replacing the default attack slot, do **not** include that here. Simple ensure 'RemoveDefaultAttackSlot' returns false.
+    /// Only return the default attack slot if you want to attack it an additional time.</remarks>
+    List<CardSlot> GetOpposingSlots(List<CardSlot> originalSlots, List<CardSlot> otherAddedSlots);
+
+    /// <summary>
+    /// If true, this means that the attack slots provided by GetOpposingSlots should override the default attack slot. 
+    /// If false, it means they should be in addition to the default opposing slot.
+    /// </summary>
+    bool RemoveDefaultAttackSlot();
+}
+
+/// <summary>
+/// Used when a card wants to provide a passive buff to other cards on the board
+/// </summary>
+public interface IPassiveAttackBuff
+{
+    /// <summary>
+    /// Used to provide a passive attack buff to a target
+    /// </summary>
+    /// <returns>The amount of attack you want to buff the target by</returns>
+    /// <remarks>Do not assume that the target is on your side of the board! There may be negative sigils that buff opposing cards.</remarks>
+    int GetPassiveAttackBuff(PlayableCard target);
+}
+
+/// <summary>
+/// Used when a card wants to provide a passive buff to other cards on the board
+/// </summary>
+public interface IPassiveHealthBuff
+{
+    /// <summary>
+    /// Used to provide a passive health buff to a target
+    /// </summary>
+    /// <returns>The amount of health you want to buff the target by</returns>
+    /// <remarks>Do not assume that the target is on your side of the board! There may be negative sigils that buff opposing cards.</remarks>
+    int GetPassiveHealthBuff(PlayableCard target);
+}


### PR DESCRIPTION
This PR adds ExtendedAbilityBehaviour back into the API, but...differently.

It adds three new 'trigger' interfaces (IPassiveAttackBuff, IPassiveHealthBuff, and IGetOpposingSlots), and changes ExtendedAbilityBehaviour to implement those three interfaces.

People who were previously implementing this abstract class still can. People who just want to implement the appropriate interface should do that instead.