### PR TITLE
Extra checks for attack buffs + minor extension refactors

### DIFF
--- a/InscryptionAPI/Card/ExtendedAbilityBehaviour.cs
+++ b/InscryptionAPI/Card/ExtendedAbilityBehaviour.cs
@@ -1,6 +1,7 @@
 using DiskCardGame;
 using HarmonyLib;
 using InscryptionAPI.Triggers;
+using Sirenix.Utilities;
 
 namespace InscryptionAPI.Card;
 
@@ -63,9 +64,10 @@ public abstract class ExtendedAbilityBehaviour : AbilityBehaviour, IGetOpposingS
     [HarmonyPostfix]
     private static void AddPassiveAttackBuffs(ref PlayableCard __instance, ref int __result)
     {
-        if (TurnManager.Instance.GameEnding) return;
-
         var card = __instance;
+        
+        if (TurnManager.Instance.GameEnding || card.SafeIsUnityNull() || card.Dead) return;
+
         __result += BoardManager.Instance.CardsOnBoard
             .SelectMany(CustomTriggerFinder.FindTriggersOnCard<IPassiveAttackBuff>)
             .Sum(buffer => buffer.GetPassiveAttackBuff(card));
@@ -75,9 +77,10 @@ public abstract class ExtendedAbilityBehaviour : AbilityBehaviour, IGetOpposingS
     [HarmonyPostfix]
     private static void AddPassiveHealthBuffs(ref PlayableCard __instance, ref int __result)
     {
-        if (TurnManager.Instance.GameEnding) return;
-
         var card = __instance;
+        
+        if (TurnManager.Instance.GameEnding || card.SafeIsUnityNull() || card.Dead) return;
+
         __result += BoardManager.Instance.CardsOnBoard
             .SelectMany(CustomTriggerFinder.FindTriggersOnCard<IPassiveHealthBuff>)
             .Sum(buffer => buffer.GetPassiveHealthBuff(card));

--- a/InscryptionAPI/Helpers/Extensions/BoardManagerExtensions.cs
+++ b/InscryptionAPI/Helpers/Extensions/BoardManagerExtensions.cs
@@ -15,7 +15,7 @@ public static class BoardManagerExtensions
         Predicate<PlayableCard> filterOnPredicate = null
     )
     {
-        return manager.PlayerSlotsCopy.GetCards(filterOnPredicate);
+        return manager.PlayerSlotsCopy.SelectCards(filterOnPredicate).ToList();
     }
 	
     /// <summary>
@@ -29,7 +29,7 @@ public static class BoardManagerExtensions
         Predicate<CardSlot> filterOnPredicate = null
     )
     {
-        return manager.PlayerSlotsCopy.OpenSlots(filterOnPredicate);
+        return manager.PlayerSlotsCopy.SelectOpenSlots(filterOnPredicate).ToList();
     }
 
     /// <summary>
@@ -43,7 +43,7 @@ public static class BoardManagerExtensions
         Predicate<PlayableCard> filterOnPredicate = null
     )
     {
-        return manager.OpponentSlotsCopy.GetCards(filterOnPredicate);
+        return manager.OpponentSlotsCopy.SelectCards(filterOnPredicate).ToList();
     }
 
     /// <summary>
@@ -57,6 +57,6 @@ public static class BoardManagerExtensions
         Predicate<CardSlot> filterOnPredicate = null
     )
     {
-        return manager.OpponentSlotsCopy.OpenSlots(filterOnPredicate);
+        return manager.OpponentSlotsCopy.SelectOpenSlots(filterOnPredicate).ToList();
     }
 }

--- a/InscryptionAPI/Helpers/Extensions/CardSlotExtensions.cs
+++ b/InscryptionAPI/Helpers/Extensions/CardSlotExtensions.cs
@@ -100,6 +100,16 @@ public static class CardSlotExtensions
     }
     
     /// <summary>
+    /// Get the adjacent cards of the slot that is being accessed.
+    /// </summary>
+    /// <param name="cardSlot">The slot that is being accessed.</param>
+    /// <returns>The list of Playable Cards that is to the left and to the right of the this slot.</returns>
+    public static List<PlayableCard> GetAdjacentCards(this CardSlot cardSlot)
+    {
+        return BoardManager.Instance.GetAdjacentSlots(cardSlot).Where(slot => slot).SelectCards().ToList();
+    }
+    
+    /// <summary>
     /// Get the adjacent slots of the slot that is being accessed.
     /// </summary>
     /// <param name="cardSlot">The slot that is being accessed.</param>
@@ -113,27 +123,24 @@ public static class CardSlotExtensions
     /// <summary>
     /// Retrieve all the PlayableCard objects from the collection of slots provided.
     /// </summary>
-    /// <param name="slots">Collection of CardSlots</param>
-    /// <param name="filterOnPredicate">Predicate to filter each slot's playable card against, if one exists.</param>
-    /// <returns>The list of cards from each slot</returns>
-    public static List<PlayableCard> GetCards(this IEnumerable<CardSlot> slots, Predicate<PlayableCard> filterOnPredicate = null)
+    /// <param name="slots">Collection of CardSlots.</param>
+    /// <param name="filterOnPredicate">Predicate to filter each slot's playable card for a condition, if one exists.</param>
+    /// <returns>An IEnumerable of PlayableCard from the CardSlots sequence.</returns>
+    public static IEnumerable<PlayableCard> SelectCards(this IEnumerable<CardSlot> slots, Predicate<PlayableCard> filterOnPredicate = null)
     {
         return slots
             .Where(slot => slot.Card && (filterOnPredicate == null || filterOnPredicate.Invoke(slot.Card)))
-            .Select(slot => slot.Card)
-            .ToList();
+            .Select(slot => slot.Card);
     }
     
     /// <summary>
     /// Retrieve all the CardSlot objects that are not occupied by a PlayableCard object.
     /// </summary>
-    /// <param name="slots">Collection of CardSlots</param>
-    /// <param name="filterOnPredicate">Predicate to filter each slot against</param>
-    /// <returns>The list of slots not occupied by a playable card.</returns>
-    public static List<CardSlot> OpenSlots(this IEnumerable<CardSlot> slots, Predicate<CardSlot> filterOnPredicate = null)
+    /// <param name="slots">Collection of CardSlots.</param>
+    /// <param name="filterOnPredicate">Predicate to test each slot for a condition.</param>
+    /// <returns>An IEnumerable of CardSlot that do not have occupying PlayableCards.</returns>
+    public static IEnumerable<CardSlot> SelectOpenSlots(this IEnumerable<CardSlot> slots, Predicate<CardSlot> filterOnPredicate = null)
     {
-        return slots
-            .Where(slot => !slot.Card && (filterOnPredicate == null || filterOnPredicate.Invoke(slot)))
-            .ToList();
+        return slots.Where(slot => !slot.Card && (filterOnPredicate == null || filterOnPredicate.Invoke(slot)));
     }
 }

--- a/InscryptionCommunityPatch/Card/PassiveAttackBuffPatches.cs
+++ b/InscryptionCommunityPatch/Card/PassiveAttackBuffPatches.cs
@@ -43,20 +43,23 @@ public static class PassiveAttackBuffPatches
             __result += __instance.Slot.GetAdjacentCards().Sum(playableCard => playableCard.AbilityCount(Ability.BuffNeighbours));
 
             // Deal with buff and debuff enemy
-            if (!__instance.HasAbility(Ability.MadeOfStone))
+            // We have to handle giant cards separately (i.e., the moon)
+            if (__instance.Info.HasTrait(Trait.Giant))
             {
-                // We have to handle giant cards separately (i.e., the moon)
-                if (__instance.Info.HasTrait(Trait.Giant))
+                foreach (CardSlot slot in BoardManager.Instance.GetSlots(__instance.OpponentCard).Where(slot => slot.Card))
                 {
-                    foreach (CardSlot slot in BoardManager.Instance.GetSlots(__instance.OpponentCard).Where(slot => slot.Card))
+                    __result += slot.Card.AbilityCount(Ability.BuffEnemy);
+                    if(__instance.LacksAbility(Ability.MadeOfStone))
                     {
-                        __result += slot.Card.AbilityCount(Ability.BuffEnemy);
                         __result -= slot.Card.AbilityCount(Ability.DebuffEnemy);
                     }
                 }
-                else if (__instance.Slot.opposingSlot.Card)
+            }
+            else if (__instance.Slot.opposingSlot.Card)
+            {
+                __result += __instance.Slot.opposingSlot.Card.AbilityCount(Ability.BuffEnemy);
+                if(__instance.LacksAbility(Ability.MadeOfStone))
                 {
-                    __result += __instance.Slot.opposingSlot.Card.AbilityCount(Ability.BuffEnemy);
                     __result -= __instance.Slot.opposingSlot.Card.AbilityCount(Ability.DebuffEnemy);
                 }
             }

--- a/InscryptionCommunityPatch/Card/PassiveAttackBuffPatches.cs
+++ b/InscryptionCommunityPatch/Card/PassiveAttackBuffPatches.cs
@@ -9,7 +9,7 @@ namespace InscryptionCommunityPatch.Card;
 [HarmonyPatch]
 public static class PassiveAttackBuffPatches
 {
-    private static int AbilityCount (this PlayableCard card, Ability ability)
+    private static int AbilityCount(this PlayableCard card, Ability ability)
     {
         int count = 0;
         count += card.Info.Abilities.Count(a => a == ability);
@@ -44,7 +44,7 @@ public static class PassiveAttackBuffPatches
 
             // Deal with buff and debuff enemy
             // We have to handle giant cards separately (i.e., the moon)
-            if (__instance.Info.HasTrait(Trait.Giant))
+            if (__instance.HasTrait(Trait.Giant))
             {
                 foreach (CardSlot slot in BoardManager.Instance.GetSlots(__instance.OpponentCard).Where(slot => slot.Card))
                 {
@@ -55,12 +55,12 @@ public static class PassiveAttackBuffPatches
                     }
                 }
             }
-            else if (__instance.Slot.opposingSlot.Card)
+            else if (__instance.HasOpposingCard())
             {
-                __result += __instance.Slot.opposingSlot.Card.AbilityCount(Ability.BuffEnemy);
+                __result += __instance.OpposingCard().AbilityCount(Ability.BuffEnemy);
                 if(__instance.LacksAbility(Ability.MadeOfStone))
                 {
-                    __result -= __instance.Slot.opposingSlot.Card.AbilityCount(Ability.DebuffEnemy);
+                    __result -= __instance.OpposingCard().AbilityCount(Ability.DebuffEnemy);
                 }
             }
 


### PR DESCRIPTION
- I kept running into more exceptions that would occur rather randomly during fights that I believe is due to the passive attack buff patch. The new conditional checks should now no longer allow any outlying problems to occur regarding the patch.

- I also added `GetAdjacentCards` extension method to compress some more lines for `BetterAttackBuffs` method along with some minor refactors. with LINQ expressions.