### PR TITLE
Improved activated ability icon fix

### DIFF
--- a/InscryptionCommunityPatch/Card/ActivatedAbilityHandler3D.cs
+++ b/InscryptionCommunityPatch/Card/ActivatedAbilityHandler3D.cs
@@ -6,7 +6,7 @@ namespace InscryptionCommunityPatch.Card;
 
 public class ActivatedAbilityHandler3D : ManagedBehaviour
 {
-    public GameObject currentIconGroup;
+    public List<AbilityIconInteractable> currentIconGroup;
     
     public List<ActivatedAbilityIconInteractable> interactables = new();
 
@@ -15,18 +15,19 @@ public class ActivatedAbilityHandler3D : ManagedBehaviour
         interactables.Add(interactable);
     }
 
-    public void UpdateInteractableList(GameObject defaultIconGroup)
+    public void UpdateInteractableList(List<AbilityIconInteractable> controllerActiveIcons)
     {
         interactables.Clear();
-        currentIconGroup = defaultIconGroup;
-        currentIconGroup
-            .GetComponentsInChildren<AbilityIconInteractable>()
+        currentIconGroup = controllerActiveIcons;
+        controllerActiveIcons
             .Where(elem => AbilitiesUtil.GetInfo(elem.Ability).activated)
             .Do(abIcon =>
             {
-                if (abIcon.GetComponent<ActivatedAbilityIconInteractable>())
+                ActivatedAbilityIconInteractable currentIcon = abIcon.gameObject.GetComponent<ActivatedAbilityIconInteractable>();
+                if (currentIcon)
                 {
-                    AddInteractable(abIcon.GetComponent<ActivatedAbilityIconInteractable>());
+                    currentIcon.AssignAbility(abIcon.Ability);
+                    AddInteractable(currentIcon);
                 }
                 else
                 {

--- a/InscryptionCommunityPatch/Card/ActivatedAbilityIconFix.cs
+++ b/InscryptionCommunityPatch/Card/ActivatedAbilityIconFix.cs
@@ -29,19 +29,16 @@ public static class ActivatedAbilityIconFix
 
         ActivatedAbilityHandler3D abilityHandler3D = __instance.GetComponent<ActivatedAbilityHandler3D>();
 
-        // at least 1 group will always be active
-        GameObject activeDefaultIconGroup = __instance.AbilityIcons.defaultIconGroups.Find(group => group.activeInHierarchy);
-
         if (abilityHandler3D.SafeIsUnityNull())
         {
             PatchPlugin.Logger.LogDebug($"[PlayableCard.OnStatsChanged] Adding activated ability handler to card [{__instance.Info.displayedName}]");
             abilityHandler3D = __instance.gameObject.AddComponent<ActivatedAbilityHandler3D>();
         }
 
-        if (abilityHandler3D.currentIconGroup != activeDefaultIconGroup)
+        if (!abilityHandler3D.SafeIsUnityNull() && __instance.AbilityIcons.abilityIcons != null)
         {
-            PatchPlugin.Logger.LogDebug($"[PlayableCard.OnStatsChanged] -> Need to reassign activated ability list as icon list has changed for card [{__instance.Info.displayedName}]");
-            abilityHandler3D.UpdateInteractableList(activeDefaultIconGroup);
+            PatchPlugin.Logger.LogDebug($"[PlayableCard.OnStatsChanged] -> Resetting icon list for [{__instance.Info.displayedName}]");
+            abilityHandler3D.UpdateInteractableList(__instance.AbilityIcons.abilityIcons);
         }
     }
 }

--- a/InscryptionCommunityPatch/Card/ActivatedAbilityIconInteractable.cs
+++ b/InscryptionCommunityPatch/Card/ActivatedAbilityIconInteractable.cs
@@ -33,6 +33,7 @@ public class ActivatedAbilityIconInteractable : MainInputInteractable
 
     public void AssignAbility(Ability ability)
     {
+        PatchPlugin.Logger.LogDebug($"Icon was previously {Ability} - asking to change to a {ability}");
         Ability = ability;
         _renderMaterial = GetComponent<Renderer>().material;
         _originalColor = _renderMaterial.color;


### PR DESCRIPTION
The current logic for the ability icons assumes that the only way that the card's ability icons can change during a game is by adding new abilities. However, it's possible to change a card and both remove and add abilities at the same time. This PR updates the ability icon interactable fix to always update the card's ability icons when stats change for any reason, and to reset the ability attached to the icon each time.

I tested this using the P03 mod - before this update, activated icons did not work with transform/evolve. They are doing so now.