### PR TITLE
Challenge bugfix and Gemified Opponent Cards

### DIFF
--- a/InscryptionAPI/Ascension/AscensionChallengePaginator.cs
+++ b/InscryptionAPI/Ascension/AscensionChallengePaginator.cs
@@ -219,6 +219,11 @@ public class AscensionChallengePaginator : MonoBehaviour
             }
             pagesToAdd.Add(page);
         }
+
+        challengeObjectsForPages.ForEach(x => x.RemoveAll(x => x == null));
+        pageIndex = 0;
+        LoadPage(0);
+
         if (pagesToAdd.Count > 0)
         {
             foreach (List<AscensionChallengeInfo> page in pagesToAdd)
@@ -260,9 +265,6 @@ public class AscensionChallengePaginator : MonoBehaviour
             rightArrow.GetComponent<AscensionMenuInteractable>().ClearDelegates();
             rightArrow.GetComponent<AscensionMenuInteractable>().CursorSelectStarted += (x) => NextPage();
         }
-        challengeObjectsForPages.ForEach(x => x.RemoveAll(x => x == null));
-        pageIndex = 0;
-        LoadPage(0);
     }
 
     public int pageIndex;

--- a/InscryptionAPI/Ascension/ChallengeManager.cs
+++ b/InscryptionAPI/Ascension/ChallengeManager.cs
@@ -22,7 +22,7 @@ public static class ChallengeManager
     /// <summary>
     /// The activated eye sprite for the "More Difficult" challenge. Can be used for other challenges with that form of eyes.
     /// </summary>
-    public static readonly Texture2D MOREDIFFICULT_ACTIVATED_SPRITE = Resources.Load<Texture2D>("art/ui/ascension/ascensionicon_activated_difficulty");
+    public static readonly Texture2D HAPPY_ACTIVATED_SPRITE = Resources.Load<Texture2D>("art/ui/ascension/ascensionicon_activated_difficulty");
 
     /// <summary>
     /// Class that stores full info about challenges, including unlock level, stackability, handlers and incompatible/dependant challenges.
@@ -444,7 +444,7 @@ public static class ChallengeManager
         string description,
         int pointValue,
         Texture2D iconTexture,
-        Texture2D activatedTexture = null,
+        Texture2D activatedTexture,
         int unlockLevel = 0,
         List<object> flags = null,
         Func<FullChallenge[], IEnumerable<AscensionChallenge>> dependantChallengeGetter = null,
@@ -477,7 +477,7 @@ public static class ChallengeManager
         string description,
         int pointValue,
         Texture2D iconTexture,
-        Texture2D activatedTexture = null,
+        Texture2D activatedTexture,
         Type handlerType = null,
         int unlockLevel = 0,
         List<object> flags = null,
@@ -492,11 +492,7 @@ public static class ChallengeManager
         info.description = description;
         info.pointValue = pointValue;
         info.iconSprite = TextureHelper.ConvertTexture(iconTexture, TextureHelper.SpriteType.ChallengeIcon);
-
-        Texture2D infoActivationTexture = activatedTexture ??
-            ((pointValue > 0) ? Resources.Load<Texture2D>("art/ui/ascension/ascensionicon_activated_default")
-                : Resources.Load<Texture2D>("art/ui/ascension/ascensionicon_activated_difficulty"));
-        info.activatedSprite = TextureHelper.ConvertTexture(infoActivationTexture, TextureHelper.SpriteType.ChallengeIcon);
+        info.activatedSprite = TextureHelper.ConvertTexture(activatedTexture, TextureHelper.SpriteType.ChallengeIcon);
 
         return AddSpecific(pluginGuid, info, handlerType, unlockLevel, flags, dependantChallengeGetter, incompatibleChallengeGetter, numAppearancesInChallengeScreen);
     }
@@ -571,7 +567,7 @@ public static class ChallengeManager
         string description,
         int pointValue,
         Texture2D iconTexture,
-        Texture2D activatedTexture = null,
+        Texture2D activatedTexture,
         int unlockLevel = 0,
         int numAppearancesInChallengeScreen = 1
     )
@@ -582,11 +578,7 @@ public static class ChallengeManager
         info.description = description;
         info.pointValue = pointValue;
         info.iconSprite = TextureHelper.ConvertTexture(iconTexture, TextureHelper.SpriteType.ChallengeIcon);
-
-        Texture2D infoActivationTexture = activatedTexture;// ??
-        //    ((pointValue > 0) ? Resources.Load<Texture2D>("art/ui/ascension/ascensionicon_activated_default")
-        //        : Resources.Load<Texture2D>("art/ui/ascension/ascensionicon_activated_difficulty"));
-        info.activatedSprite = TextureHelper.ConvertTexture(infoActivationTexture, TextureHelper.SpriteType.ChallengeIcon);
+        info.activatedSprite = TextureHelper.ConvertTexture(activatedTexture, TextureHelper.SpriteType.ChallengeIcon);
 
         return AddSpecific(pluginGuid, info, unlockLevel, numAppearancesInChallengeScreen);
     }
@@ -603,13 +595,13 @@ public static class ChallengeManager
     /// <param name="unlockLevel">The minimum level required for the challenge to be playable. Defaults to 0.</param>
     /// <param name="stackable">True if the challenge should appear twice in the challenge screen, false otherwise.</param>
     /// <returns>The built ChallengeManager.FullChallenge, with the built challenge info and other additional info.</returns>
-    public static AscensionChallengeInfo Add(
+    public static FullChallenge Add(
         string pluginGuid,
         string title,
         string description,
         int pointValue,
         Texture2D iconTexture,
-        Texture2D activatedTexture = null,
+        Texture2D activatedTexture,
         int unlockLevel = 0, 
         bool stackable = false
     )

--- a/InscryptionCommunityPatch/Card/PassiveAttackBuffPatches.cs
+++ b/InscryptionCommunityPatch/Card/PassiveAttackBuffPatches.cs
@@ -31,6 +31,22 @@ public static class PassiveAttackBuffPatches
         yield return sequence;
     }
 
+    [HarmonyPatch(typeof(PlayableCard), nameof(PlayableCard.GetPassiveHealthBuffs))]
+    [HarmonyPrefix]
+    private static bool BetterHealthBuffs(ref int __result, ref PlayableCard __instance)
+    {
+        __result = 0;
+        if (__instance.Info.Gemified)
+        {
+            if (!__instance.OpponentCard && ResourcesManager.Instance.HasGem(GemType.Green))
+                __result += 2;
+
+            if (__instance.OpponentCard && BoardManager.Instance.OpponentSlotsCopy.Any(c => c.Card != null && (c.Card.HasAbility(Ability.GainGemGreen) || c.Card.HasAbility(Ability.GainGemTriple))))
+                __result += 2;
+        }
+        return false;
+    }
+
     [HarmonyPatch(typeof(PlayableCard), nameof(PlayableCard.GetPassiveAttackBuffs))]
     [HarmonyPrefix]
     private static bool BetterAttackBuffs(ref int __result, ref PlayableCard __instance)
@@ -80,8 +96,14 @@ public static class PassiveAttackBuffPatches
                     .Sum(slot => slot.Card.AbilityCount(Ability.BuffGems));
         }
 
-        if (__instance.Info.Gemified && ResourcesManager.Instance.HasGem(GemType.Orange))
-            __result += 1;
+        if (__instance.Info.Gemified)
+        {
+            if (!__instance.OpponentCard && ResourcesManager.Instance.HasGem(GemType.Orange))
+                __result += 1;
+
+            if (__instance.OpponentCard && BoardManager.Instance.OpponentSlotsCopy.Any(c => c.Card != null && (c.Card.HasAbility(Ability.GainGemOrange) || c.Card.HasAbility(Ability.GainGemTriple))))
+                __result += 1;
+        }   
 
         return false;
     }


### PR DESCRIPTION
After approving the previous challenge update, we started plugging in additional mods for testing and found some more incompatibility and inconsistency issues. This makes the following changes:

1) There is no longer a default value for the activated sprite. Based on a cursory survey of the modding landscape, this only appears to affect Curses (my mod). Removing this will make the API behavior more easily predictable.

2) All Add methods now return the same type.

There was also a bug fix for the challenge screen regarding arrow calculations.