### PR TITLE
Fixes for console spam in Act 2

### DIFF
--- a/InscryptionCommunityPatch/Card/Act2LogSpamFixes.cs
+++ b/InscryptionCommunityPatch/Card/Act2LogSpamFixes.cs
@@ -3,6 +3,7 @@ using DiskCardGame;
 using HarmonyLib;
 using System.Reflection;
 using UnityEngine;
+using GBC;
 
 namespace InscryptionCommunityPatch.Card;
 
@@ -19,6 +20,7 @@ public class Act2LogSpamFixes
         return !SaveManager.SaveFile.IsPart2;
     }
 
+    // Since GameFlowManager is null in Act 2, there's no point in checking for that
     [HarmonyPatch(typeof(ConduitCircuitManager), nameof(ConduitCircuitManager.UpdateCircuits))]
     [HarmonyPrefix]
     private static bool RemoveConduitManagerSpam(ConduitCircuitManager __instance)
@@ -29,6 +31,14 @@ public class Act2LogSpamFixes
         __instance.UpdateCircuitsForSlots(Singleton<BoardManager>.Instance.GetSlots(getPlayerSlots: true));
         __instance.UpdateCircuitsForSlots(Singleton<BoardManager>.Instance.GetSlots(getPlayerSlots: false));
         return false;
+    }
+
+    // Prevents log spam when you open a card pack with an activated sigil in it
+    [HarmonyPatch(typeof(PixelActivatedAbilityButton), nameof(PixelActivatedAbilityButton.ManagedUpdate))]
+    [HarmonyPrefix]
+    private static bool RemovePixelActivatedSpam()
+    {
+        return SceneLoader.ActiveSceneName == "GBC_CardBattle";
     }
 
     [HarmonyPatch(typeof(TurnManager), nameof(TurnManager.SetupPhase))]
@@ -45,6 +55,7 @@ public class Act2LogSpamFixes
             yield break;
         }
 
+        // Removes unnecessary checks for Boons and Rulebook
         __instance.IsSetupPhase = true;
         Singleton<PlayerHand>.Instance.PlayingLocked = true;
         if (__instance.SpecialSequencer != null)
@@ -83,6 +94,7 @@ public class Act2LogSpamFixes
             yield break;
         }
 
+        // Removes unnecessary check for Rulebook
         __instance.PlayerWon = __instance.PlayerIsWinner();
         __instance.GameEnding = true;
 
@@ -138,6 +150,7 @@ public class Act2LogSpamFixes
             yield break;
         }
 
+        // Removes unnecessary calls to unused classes
         __instance.CardsInHand.ForEach(delegate (PlayableCard x)
         {
             x.SetEnabled(enabled: false);
@@ -202,6 +215,7 @@ public class Act2LogSpamFixes
             yield break;
         }
 
+        // removes unnecessary calls to OpponentAnimationController
         if (__instance.scales != null)
         {
             if (changeView)

--- a/InscryptionCommunityPatch/Card/Act2LogSpamFixes.cs
+++ b/InscryptionCommunityPatch/Card/Act2LogSpamFixes.cs
@@ -1,0 +1,225 @@
+using System.Collections;
+using DiskCardGame;
+using HarmonyLib;
+using System.Reflection;
+using UnityEngine;
+
+namespace InscryptionCommunityPatch.Card;
+
+// Fixes a number of warnings that get spammed in Act 2 by removing the cause of the warnings
+[HarmonyPatch]
+public class Act2LogSpamFixes
+{
+    // For parts of the game that aren't needed in Act 2
+    [HarmonyPatch(typeof(GameFlowManager), nameof(GameFlowManager.UpdateForTransitionToFirstPerson))]
+    [HarmonyPatch(typeof(ViewManager), nameof(ViewManager.UpdateViewControlsHintsForView))]
+    [HarmonyPrefix]
+    private static bool DisableInAct2()
+    {
+        return !SaveManager.SaveFile.IsPart2;
+    }
+
+    [HarmonyPatch(typeof(ConduitCircuitManager), nameof(ConduitCircuitManager.UpdateCircuits))]
+    [HarmonyPrefix]
+    private static bool RemoveConduitManagerSpam(ConduitCircuitManager __instance)
+    {
+        if (!SaveManager.SaveFile.IsPart2)
+            return true;
+
+        __instance.UpdateCircuitsForSlots(Singleton<BoardManager>.Instance.GetSlots(getPlayerSlots: true));
+        __instance.UpdateCircuitsForSlots(Singleton<BoardManager>.Instance.GetSlots(getPlayerSlots: false));
+        return false;
+    }
+
+    [HarmonyPatch(typeof(TurnManager), nameof(TurnManager.SetupPhase))]
+    [HarmonyPostfix]
+    private static IEnumerator RemoveSetupPhaseSpam(IEnumerator enumerator, TurnManager __instance, EncounterData encounterData)
+    {
+        // moved here from PassiveAttackBuffPatches - always instantiate ConduitCircuitManager on setup
+        if (ConduitCircuitManager.Instance == null)
+            BoardManager.Instance.gameObject.AddComponent<ConduitCircuitManager>();
+
+        if (!SaveManager.SaveFile.IsPart2)
+        {
+            yield return enumerator;
+            yield break;
+        }
+
+        __instance.IsSetupPhase = true;
+        Singleton<PlayerHand>.Instance.PlayingLocked = true;
+        if (__instance.SpecialSequencer != null)
+            yield return __instance.SpecialSequencer.PreBoardSetup();
+        
+        yield return new WaitForSeconds(0.15f);
+        yield return Singleton<LifeManager>.Instance.Initialize(__instance.SpecialSequencer == null || __instance.SpecialSequencer.ShowScalesOnStart);
+        __instance.StartCoroutine(Singleton<BoardManager>.Instance.Initialize());
+        __instance.StartCoroutine(Singleton<ResourcesManager>.Instance.Setup());
+        yield return new WaitForSeconds(0.2f);
+        yield return __instance.opponent.IntroSequence(encounterData);
+        __instance.StartCoroutine(__instance.PlacePreSetCards(encounterData));
+        if (__instance.SpecialSequencer != null)
+            yield return __instance.SpecialSequencer.PreDeckSetup();
+        
+        Singleton<PlayerHand>.Instance.Initialize();
+        yield return Singleton<CardDrawPiles>.Instance.Initialize();
+        if (__instance.SpecialSequencer != null)
+            yield return __instance.SpecialSequencer.PreHandDraw();
+        
+        yield return Singleton<CardDrawPiles>.Instance.DrawOpeningHand(__instance.GetFixedHand());
+        if (__instance.opponent.QueueFirstCardBeforePlayer)
+            yield return __instance.opponent.QueueNewCards(doTween: true, changeView: false);
+        
+        __instance.IsSetupPhase = false;
+        yield break;
+    }
+
+    [HarmonyPatch(typeof(TurnManager), nameof(TurnManager.CleanupPhase))]
+    [HarmonyPostfix]
+    private static IEnumerator RemoveAct2CleanupPhaseSpam(IEnumerator enumerator, TurnManager __instance)
+    {
+        if (!SaveManager.SaveFile.IsPart2)
+        {
+            yield return enumerator;
+            yield break;
+        }
+
+        __instance.PlayerWon = __instance.PlayerIsWinner();
+        __instance.GameEnding = true;
+
+        if (!__instance.PlayerWon && __instance.opponent != null && __instance.opponent.Blueprint != null)
+        {
+            AnalyticsManager.SendFailedEncounterEvent(__instance.opponent.Blueprint, __instance.opponent.Difficulty, __instance.TurnNumber);
+        }
+        if (__instance.SpecialSequencer != null)
+        {
+            yield return __instance.SpecialSequencer.PreCleanUp();
+        }
+        Singleton<ViewManager>.Instance.Controller.LockState = ViewLockState.Locked;
+        if (__instance.PlayerWon && __instance.PostBattleSpecialNode == null)
+        {
+            Singleton<ViewManager>.Instance.SwitchToView(View.MapDefault);
+        }
+        else
+        {
+            Singleton<ViewManager>.Instance.SwitchToView(View.Default);
+        }
+        yield return new WaitForSeconds(0.1f);
+        __instance.StartCoroutine(Singleton<PlayerHand>.Instance.CleanUp());
+        __instance.StartCoroutine(Singleton<CardDrawPiles>.Instance.CleanUp());
+        yield return __instance.opponent.CleanUp();
+        yield return __instance.opponent.OutroSequence(__instance.PlayerWon);
+        __instance.StartCoroutine(Singleton<BoardManager>.Instance.CleanUp());
+        __instance.StartCoroutine(Singleton<ResourcesManager>.Instance.CleanUp());
+
+        yield return Singleton<LifeManager>.Instance.CleanUp();
+        if (__instance.SpecialSequencer != null)
+        {
+            yield return __instance.SpecialSequencer.GameEnd(__instance.PlayerWon);
+        }
+
+        if (__instance.PlayerWon && SaveManager.SaveFile.IsPart3)
+        {
+            Part3SaveData.Data.IncreaseBounty(10);
+        }
+        UnityEngine.Object.Destroy(__instance.opponent.gameObject);
+
+        Singleton<PlayerHand>.Instance.SetShown(shown: false);
+        UnityEngine.Object.Destroy(__instance.SpecialSequencer);
+        yield break;
+    }
+
+    [HarmonyPatch(typeof(PlayerHand), nameof(PlayerHand.SelectSlotForCard))]
+    [HarmonyPostfix]
+    private static IEnumerator FixSelectSlotSpamInAct2(IEnumerator enumerator, PlayerHand __instance, PlayableCard card)
+    {
+        if (!SaveManager.SaveFile.IsPart2)
+        {
+            yield return enumerator;
+            yield break;
+        }
+
+        __instance.CardsInHand.ForEach(delegate (PlayableCard x)
+        {
+            x.SetEnabled(enabled: false);
+        });
+        yield return new WaitWhile(() => __instance.ChoosingSlot);
+        __instance.OnSelectSlotStartedForCard(card);
+
+        Singleton<BoardManager>.Instance.CancelledSacrifice = false;
+        __instance.choosingSlotCard = card;
+        if (card != null && card.Anim != null)
+            card.Anim.SetSelectedToPlay(selected: true);
+        
+        Singleton<BoardManager>.Instance.ShowCardNearBoard(card, showNearBoard: true);
+        if (Singleton<TurnManager>.Instance.SpecialSequencer != null)
+            yield return Singleton<TurnManager>.Instance.SpecialSequencer.CardSelectedFromHand(card);
+        
+        bool cardWasPlayed = false;
+        bool requiresSacrifices = card.Info.BloodCost > 0;
+        if (requiresSacrifices)
+        {
+            List<CardSlot> validSlots = Singleton<BoardManager>.Instance.PlayerSlotsCopy.FindAll((CardSlot x) => x.Card != null);
+            yield return Singleton<BoardManager>.Instance.ChooseSacrificesForCard(validSlots, card);
+        }
+        if (!Singleton<BoardManager>.Instance.CancelledSacrifice)
+        {
+            List<CardSlot> validSlots2 = Singleton<BoardManager>.Instance.PlayerSlotsCopy.FindAll((CardSlot x) => x.Card == null);
+            yield return Singleton<BoardManager>.Instance.ChooseSlot(validSlots2, !requiresSacrifices);
+            CardSlot lastSelectedSlot = Singleton<BoardManager>.Instance.LastSelectedSlot;
+            if (lastSelectedSlot != null)
+            {
+                cardWasPlayed = true;
+                card.Anim.SetSelectedToPlay(selected: false);
+                yield return __instance.PlayCardOnSlot(card, lastSelectedSlot);
+                if (card.Info.BonesCost > 0)
+                    yield return Singleton<ResourcesManager>.Instance.SpendBones(card.Info.BonesCost);
+                
+                if (card.EnergyCost > 0)
+                    yield return Singleton<ResourcesManager>.Instance.SpendEnergy(card.EnergyCost);
+            }
+        }
+        if (!cardWasPlayed)
+            Singleton<BoardManager>.Instance.ShowCardNearBoard(card, showNearBoard: false);
+        
+        __instance.choosingSlotCard = null;
+        if (card != null && card.Anim != null)
+            card.Anim.SetSelectedToPlay(selected: false);
+        
+        __instance.CardsInHand.ForEach(delegate (PlayableCard x)
+        {
+            x.SetEnabled(enabled: true);
+        });
+        yield break;
+    }
+
+    [HarmonyPatch(typeof(LifeManager), nameof(LifeManager.ShowDamageSequence))]
+    [HarmonyPostfix]
+    private static IEnumerator FixSequenceSpamInAct2(IEnumerator enumerator, LifeManager __instance, int damage, int numWeights, bool toPlayer, float waitAfter = 0.125f, GameObject alternateWeightPrefab = null, float waitBeforeCalcDamage = 0f, bool changeView = true)
+    {
+        if (!SaveManager.SaveFile.IsPart2)
+        {
+            yield return enumerator;
+            yield break;
+        }
+
+        if (__instance.scales != null)
+        {
+            if (changeView)
+            {
+                Singleton<ViewManager>.Instance.SwitchToView(__instance.scalesView);
+                yield return new WaitForSeconds(0.1f);
+            }
+            yield return __instance.scales.AddDamage(damage, numWeights, toPlayer, alternateWeightPrefab);
+            if (waitBeforeCalcDamage > 0f)
+                yield return new WaitForSeconds(waitBeforeCalcDamage);
+
+            if (toPlayer)
+                __instance.PlayerDamage += damage;
+            else
+                __instance.OpponentDamage += damage;
+            
+            yield return new WaitForSeconds(waitAfter);
+        }
+        yield break;
+    }
+}

--- a/InscryptionCommunityPatch/Card/Act2LogSpamFixes.cs
+++ b/InscryptionCommunityPatch/Card/Act2LogSpamFixes.cs
@@ -9,7 +9,7 @@ namespace InscryptionCommunityPatch.Card;
 
 // Fixes a number of warnings that get spammed in Act 2 by removing the cause of the warnings
 [HarmonyPatch]
-public class Act2LogSpamFixes
+internal class Act2LogSpamFixes
 {
     // For parts of the game that aren't needed in Act 2
     [HarmonyPatch(typeof(GameFlowManager), nameof(GameFlowManager.UpdateForTransitionToFirstPerson))]

--- a/InscryptionCommunityPatch/Card/PassiveAttackBuffPatches.cs
+++ b/InscryptionCommunityPatch/Card/PassiveAttackBuffPatches.cs
@@ -21,16 +21,6 @@ public static class PassiveAttackBuffPatches
             return count > 0 ? 1 : 0; // If it's not stackable, you get at most one
     }
 
-    [HarmonyPatch(typeof(TurnManager), nameof(TurnManager.SetupPhase))]
-    [HarmonyPostfix]
-    private static IEnumerator AlwaysInstantiateConduitManager(IEnumerator sequence)
-    {
-        if (ConduitCircuitManager.Instance == null)
-            BoardManager.Instance.gameObject.AddComponent<ConduitCircuitManager>();
-
-        yield return sequence;
-    }
-
     [HarmonyPatch(typeof(PlayableCard), nameof(PlayableCard.GetPassiveHealthBuffs))]
     [HarmonyPrefix]
     private static bool BetterHealthBuffs(ref int __result, ref PlayableCard __instance)

--- a/InscryptionCommunityPatch/Card/SelfAttackDamagePatch.cs
+++ b/InscryptionCommunityPatch/Card/SelfAttackDamagePatch.cs
@@ -21,10 +21,10 @@ public class SelfAttackDamagePatch
     private const string name_CombatCurrent = "System.Object <>2__current";
 
     // Get the method MoveNext, which is where the actual code for SlotAttackSlot is located
-    private static IEnumerable<MethodBase> TargetMethods()
+    private static MethodBase TargetMethod()
     {
         MethodBase baseMethod = AccessTools.Method(typeof(CombatPhaseManager), nameof(CombatPhaseManager.DoCombatPhase));
-        yield return AccessTools.EnumeratorMoveNext(baseMethod);
+        return AccessTools.EnumeratorMoveNext(baseMethod);
     }
 
     // We want to add support for negative values of DamageDealtThisPhase so modders can add self damage behaviours more easily

--- a/InscryptionCommunityPatch/Card/SlotAttackSlotFixes.cs
+++ b/InscryptionCommunityPatch/Card/SlotAttackSlotFixes.cs
@@ -19,10 +19,10 @@ public class SlotAttackSlotPatches
     private const string name_SetDamageDealt = "Void set_DamageDealtThisPhase(Int32)";
 
     // Get the method MoveNext, which is where the actual code for SlotAttackSlot is located
-    private static IEnumerable<MethodBase> TargetMethods()
+    private static MethodBase TargetMethod()
     {
         MethodBase baseMethod = AccessTools.Method(typeof(CombatPhaseManager), nameof(CombatPhaseManager.SlotAttackSlot));
-        yield return AccessTools.EnumeratorMoveNext(baseMethod);
+        return AccessTools.EnumeratorMoveNext(baseMethod);
     }
 
     // We want to add a null check after CardGettingAttacked is triggered, so we'll look for triggers

--- a/InscryptionCommunityPatch/ResourceManagers/ActOneEnergyDrone.cs
+++ b/InscryptionCommunityPatch/ResourceManagers/ActOneEnergyDrone.cs
@@ -124,14 +124,9 @@ public static class EnergyDrone
 
     internal static void TryEnableEnergy(string sceneName)
     {
-        PatchPlugin.Logger.LogDebug($"Checking to see if I need to enable energy for scene {sceneName}");
-
         // We only need to do this in these specific scenes.
         if (!SceneCanHaveEnergyDrone(sceneName))
-        {
-            PatchPlugin.Logger.LogDebug($"The active scene should not have the energy drone");
             return;
-        }
 
         // Check the entire pool of cards for mox and energy
         CardTemple targetTemple = SaveManager.saveFile.IsGrimora ? CardTemple.Undead : 


### PR DESCRIPTION
Fixes multiple instances of console spam in Act 2 due to null instances
Does this by either disabling the offending code if possible (most of the null instance warnings are for instances that aren't used in Act 2 and thus don't need to be called/checked) or making modifications to avoid calling the null instance while in Act 2

Also removes the debug messages from the Act1EnergyDronePatch that inform the user when it's checking the active scene, as they logged at unnecessary times (eg, starting screen, loading screens, etc.)

Miscellaneous tweaks to a couple of my prior fixes that were using TargetMethods instead of TargetMethod