### PR TITLE
Fix for Latch deleting campfire boosts

### DIFF
--- a/InscryptionCommunityPatch/Card/Act1LatchAbilityFix.cs
+++ b/InscryptionCommunityPatch/Card/Act1LatchAbilityFix.cs
@@ -173,7 +173,7 @@ public class Act1LatchAbilityFix
                     mod.fromLatch = true;
                 }
                 selectedSlot.Card.AddTemporaryMod(mod);
-                selectedSlot.Card.RenderInfo.forceEmissivePortrait = !SaveManager.SaveFile.IsGrimora;
+                selectedSlot.Card.RenderInfo.forceEmissivePortrait = true;
                 selectedSlot.Card.UpdateStatsText();
             
                 selectedSlot.Card.Anim.PlayTransformAnimation();

--- a/InscryptionCommunityPatch/Card/Act1LatchAbilityFix.cs
+++ b/InscryptionCommunityPatch/Card/Act1LatchAbilityFix.cs
@@ -162,23 +162,20 @@ public class Act1LatchAbilityFix
 
             if (selectedSlot != null && selectedSlot.Card != null)
             {
-                CardModificationInfo mod = new CardModificationInfo(__state.LatchAbility)
-                {
-                    fromCardMerge = true,
-                    fromLatch = true
-                };
+                CardModificationInfo mod = new CardModificationInfo(__state.LatchAbility);
+
                 PatchPlugin.Logger.LogInfo($"[LatchFix] Selected card name [{selectedSlot.Card.name}]");
 
-                if (selectedSlot.Card.Info.name == "!DEATHCARD_BASE")
+                // sigil patches don't render in Grimora's act, so only set these to true if we're not in Grimora's act
+                if (!SaveManager.SaveFile.IsGrimora)
                 {
-                    selectedSlot.Card.AddTemporaryMod(mod);
+                    mod.fromCardMerge = true;
+                    mod.fromLatch = true;
                 }
-                else
-                {
-                    CardInfo info = selectedSlot.Card.Info.Clone() as CardInfo;
-                    info.Mods.Add(mod);
-                    selectedSlot.Card.SetInfo(info);
-                }
+                selectedSlot.Card.AddTemporaryMod(mod);
+                selectedSlot.Card.RenderInfo.forceEmissivePortrait = !SaveManager.SaveFile.IsGrimora;
+                selectedSlot.Card.UpdateStatsText();
+            
                 selectedSlot.Card.Anim.PlayTransformAnimation();
                 __state.OnSuccessfullyLatched(selectedSlot.Card);
 

--- a/InscryptionCommunityPatch/Card/Act1LatchAbilityFix.cs
+++ b/InscryptionCommunityPatch/Card/Act1LatchAbilityFix.cs
@@ -162,16 +162,15 @@ public class Act1LatchAbilityFix
 
             if (selectedSlot != null && selectedSlot.Card != null)
             {
-                CardModificationInfo mod = new CardModificationInfo(__state.LatchAbility);
+                CardModificationInfo mod = new CardModificationInfo(__state.LatchAbility)
+                {
+                    fromCardMerge = SaveManager.SaveFile.IsPart1,
+                    fromLatch = SaveManager.SaveFile.IsPart1 || SaveManager.SaveFile.IsPart3
+                };
 
                 PatchPlugin.Logger.LogInfo($"[LatchFix] Selected card name [{selectedSlot.Card.name}]");
 
                 // sigil patches don't render in Grimora's act, so only set these to true if we're not in Grimora's act
-                if (!SaveManager.SaveFile.IsGrimora)
-                {
-                    mod.fromCardMerge = true;
-                    mod.fromLatch = true;
-                }
                 selectedSlot.Card.AddTemporaryMod(mod);
                 selectedSlot.Card.RenderInfo.forceEmissivePortrait = true;
                 selectedSlot.Card.UpdateStatsText();


### PR DESCRIPTION
Fixes the Latch fix removing campfire stat boosts when applying a sigil.

Also fixed a render issue with Latched sigils in Grimora's Act.