### PR TITLE
Item and totem top Fixes

### DIFF
--- a/Models/Custom/CustomCard.cs
+++ b/Models/Custom/CustomCard.cs
@@ -15,6 +15,7 @@ namespace APIPlugin
 		public static Dictionary<int,TailIdentifier> tailIds = new();
 
 		public static Dictionary<string, Sprite> emissions = new();
+		public static Dictionary<string, Sprite> altEmissions = new();
 
 		public string name;
 		public List<CardMetaCategory> metaCategories;
@@ -46,6 +47,7 @@ namespace APIPlugin
 		public Texture titleGraphic;
 		[IgnoreMapping] public Texture2D pixelTex;
 		[IgnoreMapping] public Texture2D emissionTex;
+		[IgnoreMapping] public Texture2D altEmissionTex;
 		public GameObject animatedPortrait;
 		public List<Texture> decals;
 
@@ -122,6 +124,14 @@ namespace APIPlugin
 				altTex.filterMode = FilterMode.Point;
 				card.alternatePortrait = Sprite.Create(altTex, CardUtils.DefaultCardArtRect, CardUtils.DefaultVector2);
 				card.alternatePortrait.name = "portrait_" + name;
+				if (this.altEmissionTex is not null)
+				{
+					altEmissionTex.name = tex.name + "_emission";
+					altEmissionTex.filterMode = FilterMode.Point;
+					Sprite emissionSprite = Sprite.Create(altEmissionTex, CardUtils.DefaultCardArtRect, CardUtils.DefaultVector2);
+					emissionSprite.name = tex.name + "_emission";
+					altEmissions.Add(tex.name, emissionSprite);
+				}
 			}
 
 			Plugin.Log.LogDebug($"Checking pixelTex is not null...");

--- a/Models/New/NewCard.cs
+++ b/Models/New/NewCard.cs
@@ -19,6 +19,7 @@ namespace APIPlugin
 		public static Dictionary<int, TailIdentifier> tailIds = new();
 
 		public static Dictionary<string, Sprite> emissions = new();
+		public static Dictionary<string, Sprite> altEmissions = new();
 
 		public static void Add(CardInfo card, List<AbilityIdentifier> abilityIdsParam = null,
 			List<SpecialAbilityIdentifier> specialAbilitiesIdsParam = null,
@@ -46,7 +47,7 @@ namespace APIPlugin
 			bool flipPortraitForStrafe = false, bool onePerDeck = false,
 			List<CardAppearanceBehaviour.Appearance> appearanceBehaviour = null, Texture2D defaultTex = null,
 			Texture2D altTex = null, Texture titleGraphic = null, Texture2D pixelTex = null,
-			Texture2D emissionTex = null, GameObject animatedPortrait = null, List<Texture> decals = null,
+			Texture2D emissionTex = null, Texture2D altEmissionTex = null, GameObject animatedPortrait = null, List<Texture> decals = null,
 			EvolveIdentifier evolveId = null, IceCubeIdentifier iceCubeId = null, TailIdentifier tailId = null)
 		{
 			CardInfo card = ScriptableObject.CreateInstance<CardInfo>();
@@ -123,7 +124,7 @@ namespace APIPlugin
 			}
 
 			// textures
-			DetermineAndSetCardArt(name, card, defaultTex, altTex, pixelTex, emissionTex);
+			DetermineAndSetCardArt(name, card, defaultTex, altTex, pixelTex, emissionTex, altEmissionTex);
 
 			if (animatedPortrait is not null)
 			{
@@ -229,7 +230,7 @@ namespace APIPlugin
 
 		private static void DetermineAndSetCardArt(
 			string name, CardInfo card,
-			Texture2D defaultTex, Texture2D altTex, Texture2D pixelTex, Texture2D emissionTex)
+			Texture2D defaultTex, Texture2D altTex, Texture2D pixelTex, Texture2D emissionTex, Texture2D altEmissionTex)
 		{
 			var newName = "portrait_" + name;
 			if (defaultTex is not null)
@@ -256,6 +257,23 @@ namespace APIPlugin
 
 				card.alternatePortrait = Sprite.Create(altTex, CardUtils.DefaultCardArtRect, CardUtils.DefaultVector2);
 				card.alternatePortrait.name = newName;
+				if (altEmissionTex is not null)
+				{
+					Plugin.Log.LogInfo(newName + " found alt Emission!!!!!!!!!!!!!!!!!!!!!!!!!!");
+					altEmissionTex.name = newName + "_emission";
+					altEmissionTex.filterMode = FilterMode.Point;
+					Sprite emissionSprite = Sprite.Create(altEmissionTex, CardUtils.DefaultCardArtRect, CardUtils.DefaultVector2);
+					emissionSprite.name = newName + "_emission";
+					altEmissions.Add(newName, emissionSprite);
+				}
+				else
+				{
+					Plugin.Log.LogInfo(newName + " no alt Emission.");
+				}
+			}
+			else
+			{
+				Plugin.Log.LogInfo(newName + " not alt Texture.");
 			}
 
 			if (pixelTex is not null)

--- a/Patches/CardDisplayer3D.cs
+++ b/Patches/CardDisplayer3D.cs
@@ -11,16 +11,33 @@ namespace API.Patches
 		static bool Prefix(Sprite mainPortrait, ref Sprite __result)
 		{
 			Sprite sprite;
+			if (RunState.Run.eyeState == EyeballState.Goat)
+			{
+				if (NewCard.altEmissions.TryGetValue(mainPortrait.name, out sprite))
+				{
+					__result = sprite;
+					return false;
+				}
+
+				if (CustomCard.altEmissions.TryGetValue(mainPortrait.name, out sprite))
+				{
+					__result = sprite;
+					return false;
+				}
+			}
+			
 			if (NewCard.emissions.TryGetValue(mainPortrait.name, out sprite))
 			{
 				__result = sprite;
 				return false;
 			}
+
 			if (CustomCard.emissions.TryGetValue(mainPortrait.name, out sprite))
 			{
 				__result = sprite;
 				return false;
 			}
+
 			return true;
 		}
 	}


### PR DESCRIPTION
- Added `CanActivateOutsideBattles` extension method to ConsumableItemData so they can be used outside of battles.
- Added Missing Tribe Icon fallback texture for totem tops when a tribe has no icon
- Changed TotemManager to accept a `CompositeTotemPiece` type for custom behaviour other than always a custom icon
- Fixed lag when entering gain consumable item map node
- Fixed crash when using custom consumable items
- Fixed hard lock when getting totem top that doesn't have an icon