### PR TITLE
New helper methods, feature

### DIFF
--- a/InscryptionAPI/Card/AbilityExtensions.cs
+++ b/InscryptionAPI/Card/AbilityExtensions.cs
@@ -1,6 +1,7 @@
 using DiskCardGame;
 using InscryptionAPI.Helpers;
 using UnityEngine;
+using static InscryptionAPI.Card.AbilityManager;
 
 namespace InscryptionAPI.Card;
 
@@ -229,9 +230,221 @@ public static class AbilityExtensions
     /// Helper method: automatically adds the Part3Rulebook metacategories to the stat icon
     /// </summary>
     /// <param name="info">The instance of StatIconInfo</param>
-    /// <returns>The same stati icon so a chain can continue</returns>
+    /// <returns>The same stat icon so a chain can continue</returns>
     public static StatIconInfo SetDefaultPart3Ability(this StatIconInfo info)
     {
         return info.AddMetaCategories(AbilityMetaCategory.Part3Rulebook);
     }
+
+    /// <summary>
+    /// Sets whether or not the ability is an activated ability.
+    /// </summary>
+    /// <param name="abilityInfo">The instance of AbilityInfo</param>
+    /// <param name="activated">If the ability is activated.</param>
+    /// <returns>The same AbilityInfo so a chain can continue</returns>
+    public static AbilityInfo SetActivated(this AbilityInfo abilityInfo, bool activated = true)
+    {
+        abilityInfo.activated = activated;
+        return abilityInfo;
+    }
+    /// <summary>
+    /// Sets whether or not the ability is passive (will not trigger).
+    /// </summary>
+    /// <param name="abilityInfo">The instance of AbilityInfo</param>
+    /// <param name="passive">If the ability is passive.</param>
+    /// <returns>The same AbilityInfo so a chain can continue</returns>
+    public static AbilityInfo SetPassive(this AbilityInfo abilityInfo, bool passive = true)
+    {
+        abilityInfo.passive = passive;
+        return abilityInfo;
+    }
+    /// <summary>
+    /// Sets whether or not the ability can be used by the opponent.
+    /// </summary>
+    /// <param name="abilityInfo">The instance of AbilityInfo</param>
+    /// <param name="opponentUsable">If the ability is usable by the opponent.</param>
+    /// <returns>The same AbilityInfo so a chain can continue</returns>
+    public static AbilityInfo SetOpponentUsable(this AbilityInfo abilityInfo, bool opponentUsable = true)
+    {
+        abilityInfo.opponentUsable = opponentUsable;
+        return abilityInfo;
+    }
+    /// <summary>
+    /// Sets whether or not the ability is a conduit.
+    /// </summary>
+    /// <param name="abilityInfo">The instance of AbilityInfo</param>
+    /// <param name="conduit">If the ability is a conduit.</param>
+    /// <returns>The same AbilityInfo so a chain can continue</returns>
+    public static AbilityInfo SetConduit(this AbilityInfo abilityInfo, bool conduit = true)
+    {
+        abilityInfo.conduit = conduit;
+        return abilityInfo;
+    }
+    /// <summary>
+    /// Sets whether or not the ability is a conduit cell.
+    /// </summary>
+    /// <param name="abilityInfo">The instance of AbilityInfo</param>
+    /// <param name="conduitCell">If the ability is a conduit cell.</param>
+    /// <returns>The same AbilityInfo so a chain can continue</returns>
+    public static AbilityInfo SetConduitCell(this AbilityInfo abilityInfo, bool conduitCell = true)
+    {
+        abilityInfo.conduitCell = conduitCell;
+        return abilityInfo;
+    }
+
+    /// <summary>
+    /// Sets whether or not the ability can stack on a card, triggering once for each stack.
+    /// Optional parameter for setting the ability to only trigger once per stack when a card evolves (only affects abilities that can stack).
+    /// </summary>
+    /// <param name="abilityInfo">The instance of AbilityInfo</param>
+    /// <param name="triggersOncePerStack">Whether or not to prevent double triggering.</param>
+    /// <returns>The same AbilityInfo so a chain can continue</returns>
+    public static AbilityInfo SetCanStack(this AbilityInfo abilityInfo, bool canStack = true, bool triggersOncePerStack = false)
+    {
+        abilityInfo.canStack = canStack;
+        abilityInfo.SetTriggersOncePerStack(triggersOncePerStack);
+        return abilityInfo;
+    }
+
+    /// <summary>
+    /// Sets the ability to only ever trigger once per stack. This prevents abilities from triggering twice per stack after a card evolves.
+    /// This only affects cards that evolve into a card that possesses the same stackable ability (eg, default evolutions).
+    /// </summary>
+    /// <param name="abilityInfo">The instance of AbilityInfo</param>
+    /// <param name="triggersOncePerStack">Whether or not to prevent double triggering.</param>
+    /// <returns>The same AbilityInfo so a chain can continue</returns>
+    public static AbilityInfo SetTriggersOncePerStack(this AbilityInfo abilityInfo, bool triggersOncePerStack = true)
+    {
+        abilityInfo.SetExtendedProperty("TriggersOncePerStack", triggersOncePerStack);
+        return abilityInfo;
+    }
+
+    /// <summary>
+    /// Gets the value of TriggersOncePerStack. Returns false if TriggersOncePerStack has not been set.
+    /// </summary>
+    /// <param name="abilityInfo">Ability to access</param>
+    /// <returns>Whether double triggering is disabled.</returns>
+    public static bool GetTriggersOncePerStack(this Ability ability)
+    {
+        AbilityInfo abilityInfo = AllAbilityInfos.AbilityByID(ability);
+        return abilityInfo.GetTriggersOncePerStack();
+    }
+    /// <summary>
+    /// Gets the value of TriggersOncePerStack. Returns false if TriggersOncePerStack has not been set.
+    /// </summary>
+    /// <param name="abilityInfo">The instance of AbilityInfo</param>
+    /// <returns>Whether double triggering is disabled.</returns>
+    public static bool GetTriggersOncePerStack(this AbilityInfo abilityInfo)
+    {
+        return abilityInfo.GetExtendedPropertyAsBool("TriggersOncePerStack") ?? false;
+    }
+
+    #region ExtendedProperties
+
+    /// <summary>
+    /// Adds a custom property value to the ability.
+    /// </summary>
+    /// <param name="info">Ability to access</param>
+    /// <param name="propertyName">The name of the property to set</param>
+    /// <param name="value">The value of the property</param>
+    /// <returns>The same AbilityInfo so a chain can continue</returns>
+    public static AbilityInfo SetExtendedProperty(this AbilityInfo info, string propertyName, object value)
+    {
+        info.GetAbilityExtensionTable()[propertyName] = value?.ToString();
+        return info;
+    }
+
+    /// <summary>
+    /// Gets a custom property value from the card
+    /// </summary>
+    /// <param name="ability">Ability to access</param>
+    /// <param name="propertyName">The name of the property to get the value of</param>
+    /// <returns></returns>
+    public static string GetExtendedProperty(this Ability ability, string propertyName)
+    {
+        AbilityInfo info = AllAbilityInfos.AbilityByID(ability);
+        return info.GetExtendedProperty(propertyName);
+    }
+    /// <summary>
+    /// Gets a custom property value from the card
+    /// </summary>
+    /// <param name="info">Ability to access</param>
+    /// <param name="propertyName">The name of the property to get the value of</param>
+    /// <returns></returns>
+    public static string GetExtendedProperty(this AbilityInfo info, string propertyName)
+    {
+        info.GetAbilityExtensionTable().TryGetValue(propertyName, out var ret);
+        return ret;
+    }
+
+    /// <summary>
+    /// Gets a custom property as an int (can by null)
+    /// </summary>
+    /// <param name="ability">Ability to access</param>
+    /// <param name="propertyName">Property name to get value of</param>
+    /// <returns>Returns the value of the property as an int or null if it didn't exist or couldn't be parsed as int</returns>
+    public static int? GetExtendedPropertyAsInt(this Ability ability, string propertyName)
+    {
+        AbilityInfo info = AllAbilityInfos.AbilityByID(ability);
+        return info.GetExtendedPropertyAsInt(propertyName);
+    }
+    /// <summary>
+    /// Gets a custom property as an int (can by null)
+    /// </summary>
+    /// <param name="info">Ability to access</param>
+    /// <param name="propertyName">Property name to get value of</param>
+    /// <returns>Returns the value of the property as an int or null if it didn't exist or couldn't be parsed as int</returns>
+    public static int? GetExtendedPropertyAsInt(this AbilityInfo info, string propertyName)
+    {
+        info.GetAbilityExtensionTable().TryGetValue(propertyName, out var str);
+        return int.TryParse(str, out var ret) ? ret : null;
+    }
+
+    /// <summary>
+    /// Gets a custom property as a float (can by null)
+    /// </summary>
+    /// <param name="ability">Ability to access</param>
+    /// <param name="propertyName">Property name to get value of</param>
+    /// <returns>Returns the value of the property as a float or null if it didn't exist or couldn't be parsed as float</returns>
+    public static float? GetExtendedPropertyAsFloat(this Ability ability, string propertyName)
+    {
+        AbilityInfo info = AllAbilityInfos.AbilityByID(ability);
+        return info.GetExtendedPropertyAsFloat(propertyName);
+    }
+    /// <summary>
+    /// Gets a custom property as a float (can by null)
+    /// </summary>
+    /// <param name="info">Ability to access</param>
+    /// <param name="propertyName">Property name to get value of</param>
+    /// <returns>Returns the value of the property as a float or null if it didn't exist or couldn't be parsed as float</returns>
+    public static float? GetExtendedPropertyAsFloat(this AbilityInfo info, string propertyName)
+    {
+        info.GetAbilityExtensionTable().TryGetValue(propertyName, out var str);
+        return float.TryParse(str, out var ret) ? ret : null;
+    }
+
+    /// <summary>
+    /// Gets a custom property as a boolean (can be null)
+    /// </summary>
+    /// <param name="ability">Ability to access</param>
+    /// <param name="propertyName">Property name to get value of</param>
+    /// <returns>Returns the value of the property as a boolean or null if it didn't exist or couldn't be parsed as boolean</returns>
+    public static bool? GetExtendedPropertyAsBool(this Ability ability, string propertyName)
+    {
+        AbilityInfo info = AllAbilityInfos.AbilityByID(ability);
+        return info.GetExtendedPropertyAsBool(propertyName);
+    }
+    /// <summary>
+    /// Gets a custom property as a boolean (can be null)
+    /// </summary>
+    /// <param name="info">Ability to access</param>
+    /// <param name="propertyName">Property name to get value of</param>
+    /// <returns>Returns the value of the property as a boolean or null if it didn't exist or couldn't be parsed as boolean</returns>
+    public static bool? GetExtendedPropertyAsBool(this AbilityInfo info, string propertyName)
+    {
+        info.GetAbilityExtensionTable().TryGetValue(propertyName, out var str);
+        return bool.TryParse(str, out var ret) ? ret : null;
+    }
+    
+    #endregion
 }

--- a/InscryptionAPI/Card/CardExtensions.cs
+++ b/InscryptionAPI/Card/CardExtensions.cs
@@ -154,7 +154,7 @@ public static class CardExtensions
     /// <param name="info">Card to access</param>
     /// <param name="abilities">The abilities to remove</param>
     /// <returns>The same card info so a chain can continue</returns>
-    public static CardInfo RemoveAllBaseAbilities(this CardInfo info, params Ability[] abilities)
+    public static CardInfo RemoveAbilities(this CardInfo info, params Ability[] abilities)
     {
         if (info.abilities?.Count > 0)
         {
@@ -171,7 +171,7 @@ public static class CardExtensions
     /// <param name="info">Card to access</param>
     /// <param name="abilities">The abilities to remove</param>
     /// <returns>The same card info so a chain can continue</returns>
-    public static CardInfo RemoveBaseAbilities(this CardInfo info, params Ability[] abilities)
+    public static CardInfo RemoveAbilitiesSingle(this CardInfo info, params Ability[] abilities)
     {
         if (info.abilities?.Count > 0)
         {

--- a/InscryptionAPI/Card/CardExtensions.cs
+++ b/InscryptionAPI/Card/CardExtensions.cs
@@ -27,7 +27,7 @@ public static class CardExtensions
     #region Adders
 
     /// <summary>
-    /// Adds any number of abilities to the the card. Abilities can be added multiple times.
+    /// Adds any number of abilities to the card. Abilities can be added multiple times.
     /// </summary>
     /// <param name="info">Card to access</param>
     /// <param name="abilities">The abilities to add</param>
@@ -40,7 +40,7 @@ public static class CardExtensions
     }
 
     /// <summary>
-    /// Adds any number of appearance behaviors to the the card. Duplicate appearance behaviors are ignored.
+    /// Adds any number of appearance behaviors to the card. Duplicate appearance behaviors are ignored.
     /// </summary>
     /// <param name="info">Card to access</param>
     /// <param name="appearances">The appearances to add</param>
@@ -55,7 +55,7 @@ public static class CardExtensions
     }
 
     /// <summary>
-    /// Adds any number of decals to the the card. Duplicate decals are ignored.
+    /// Adds any number of decals to the card. Duplicate decals are ignored.
     /// </summary>
     /// <param name="info">Card to access</param>
     /// <param name="decals">The decals to add</param>
@@ -71,7 +71,7 @@ public static class CardExtensions
     }
 
     /// <summary>
-    /// Adds any number of decals to the the card. Duplicate decals are ignored.
+    /// Adds any number of decals to the card. Duplicate decals are ignored.
     /// </summary>
     /// <param name="info">Card to access</param>
     /// <param name="decals">The paths to the .png files containing the decals (relative to the Plugins directory)</param>
@@ -85,7 +85,7 @@ public static class CardExtensions
     }
 
     /// <summary>
-    /// Adds any number of metacategories to the the card. Duplicate metacategories are ignored.
+    /// Adds any number of metacategories to the card. Duplicate metacategories are ignored.
     /// </summary>
     /// <param name="info">Card to access</param>
     /// <param name="categories">The categories to add</param>
@@ -100,7 +100,7 @@ public static class CardExtensions
     }
 
     /// <summary>
-    /// Adds any number of special abilities to the the card. Duplicate special abilities are ignored.
+    /// Adds any number of special abilities to the card. Duplicate special abilities are ignored.
     /// </summary>
     /// <param name="info">Card to access</param>
     /// <param name="abilities">The abilities to add</param>
@@ -115,7 +115,7 @@ public static class CardExtensions
     }
 
     /// <summary>
-    /// Adds any number of traits to the the card. Duplicate traits are ignored.
+    /// Adds any number of traits to the card. Duplicate traits are ignored.
     /// </summary>
     /// <param name="info">Card to access</param>
     /// <param name="traits">The traits to add</param>
@@ -130,7 +130,7 @@ public static class CardExtensions
     }
 
     /// <summary>
-    /// Adds any number of tribes to the the card. Duplicate tribes are ignored.
+    /// Adds any number of tribes to the card. Duplicate tribes are ignored.
     /// </summary>
     /// <param name="info">Card to access</param>
     /// <param name="tribes">The tribes to add</param>
@@ -141,6 +141,82 @@ public static class CardExtensions
         foreach (var app in tribes)
             if (!info.tribes.Contains(app))
                 info.tribes.Add(app);
+        return info;
+    }
+
+    #endregion
+
+    #region Removers
+
+    /// <summary>
+    /// Removes all stacks of any number of abilities from the card.
+    /// </summary>
+    /// <param name="info">Card to access</param>
+    /// <param name="abilities">The abilities to remove</param>
+    /// <returns>The same card info so a chain can continue</returns>
+    public static CardInfo RemoveAllBaseAbilities(this CardInfo info, params Ability[] abilities)
+    {
+        if (info.abilities?.Count > 0)
+        {
+            foreach (Ability ab in abilities)
+            {
+                info.abilities.RemoveAll(a => a == ab);
+            }
+        }
+        return info;
+    }
+    /// <summary>
+    /// Removes any number of abilities from the card. Will remove one instance of each passed ability; multiple instances can be passed.
+    /// </summary>
+    /// <param name="info">Card to access</param>
+    /// <param name="abilities">The abilities to remove</param>
+    /// <returns>The same card info so a chain can continue</returns>
+    public static CardInfo RemoveBaseAbilities(this CardInfo info, params Ability[] abilities)
+    {
+        if (info.abilities?.Count > 0)
+        {
+            foreach (Ability ab in abilities)
+            {
+                info.abilities.Remove(ab);
+            }
+        }
+        return info;
+    }
+
+    /// <summary>
+    /// Removes any number of traits from the card.
+    /// </summary>
+    /// <param name="info">Card to access</param>
+    /// <param name="traits">The traits to remove</param>
+    /// <returns>The same card info so a chain can continue</returns>
+    public static CardInfo RemoveTraits(this CardInfo info, params Trait[] traits)
+    {
+        if (info.traits?.Count > 0)
+        {
+            foreach (Trait tr in traits)
+            {
+                if (info.HasTrait(tr))
+                    info.traits.Remove(tr);
+            }
+        }
+        return info;
+    }
+    /// <summary>
+    /// Removes any number of traits from the card.
+    /// </summary>
+    /// <param name="info">Card to access</param>
+    /// <param name="tribes">The tribes to remove</param>
+    /// <returns>The same card info so a chain can continue</returns>
+    public static CardInfo RemoveTribes(this CardInfo info, params Tribe[] tribes)
+    {
+        if (info.traits?.Count > 0)
+        {
+            foreach (Tribe tr in tribes)
+            {
+                if (info.IsOfTribe(tr))
+                    info.tribes.Remove(tr);
+            }
+        }
         return info;
     }
 
@@ -249,7 +325,7 @@ public static class CardExtensions
     }
 
     /// <summary>
-    /// Sets any number of special abilities to the the card.
+    /// Sets any number of special abilities to the card.
     /// </summary>
     /// <param name="info">Card to access</param>
     /// <param name="abilities">The abilities to add</param>
@@ -274,7 +350,7 @@ public static class CardExtensions
     }
 
     /// <summary>
-    /// Sets any number of traits to the the card.
+    /// Sets any number of traits to the card.
     /// </summary>
     /// <param name="info">Card to access</param>
     /// <param name="traits">The traits to add</param>
@@ -287,7 +363,7 @@ public static class CardExtensions
 
 
     /// <summary>
-    /// Set any number of tribes to the the card.
+    /// Set any number of tribes to the card.
     /// </summary>
     /// <param name="info">Card to access</param>
     /// <param name="tribes">The tribes to add</param>
@@ -714,6 +790,33 @@ public static class CardExtensions
     public static CardInfo SetGemsCost(this CardInfo info, List<GemType> gemsCost = null)
     {
         info.gemsCost = gemsCost ?? new();
+        return info;
+    }
+
+    #endregion
+
+    #region Bools
+
+    /// <summary>
+    /// Sets whether the card is onePerDeck or not.
+    /// </summary>
+    /// <param name="info">Card to access</param>
+    /// <param name="onePerDeck">Whether this is onePerDeck or not</param>
+    /// <returns>The same card info so a chain can continue</returns>
+    internal static CardInfo SetOnePerDeck(this CardInfo info, bool onePerDeck = true)
+    {
+        info.onePerDeck = onePerDeck;
+        return info;
+    }
+    /// <summary>
+    /// Sets whether the card's Power and Health will be displayed or not.
+    /// </summary>
+    /// <param name="info">Card to access</param>
+    /// <param name="hideStats">Whether the stats should be hidden or not</param>
+    /// <returns>The same card info so a chain can continue</returns>
+    internal static CardInfo SetHideStats(this CardInfo info, bool hideStats = true)
+    {
+        info.hideAttackAndHealth = hideStats;
         return info;
     }
 
@@ -1831,6 +1934,7 @@ public static class CardExtensions
         return c;
     }
 
+    #region OldAPICard
     internal static CardInfo SetOldApiCard(this CardInfo info, bool isOldApiCard = true)
     {
         info.SetExtendedProperty("AddedByOldApi", isOldApiCard);
@@ -1842,4 +1946,5 @@ public static class CardExtensions
         bool? isOAPI = info.GetExtendedPropertyAsBool("AddedByOldApi");
         return isOAPI.HasValue && isOAPI.Value;
     }
+    #endregion
 }

--- a/InscryptionAPI/Card/CardManager.cs
+++ b/InscryptionAPI/Card/CardManager.cs
@@ -19,7 +19,7 @@ public static class CardManager
         public readonly Dictionary<Type, object> TypeMap = new();
         public readonly Dictionary<string, string> StringMap = new();
     }
-    private static readonly ConditionalWeakTable<CardInfo, CardExt> ExtensionProperties = new();
+    private static readonly ConditionalWeakTable<CardInfo, CardExt> CardExtensionProperties = new();
 
     internal static readonly Dictionary<string, Func<bool, int, bool>> CustomCardUnlocks = new();
 
@@ -246,7 +246,7 @@ public static class CardManager
     /// <returns>The instance of T for this card</returns>
     public static T GetExtendedClass<T>(this CardInfo card) where T : class, new()
     {
-        var typeMap = ExtensionProperties.GetOrCreateValue(card).TypeMap;
+        var typeMap = CardExtensionProperties.GetOrCreateValue(card).TypeMap;
         if (typeMap.TryGetValue(typeof(T), out object tObj))
         {
             return (T)tObj;
@@ -261,7 +261,7 @@ public static class CardManager
 
     internal static Dictionary<string, string> GetCardExtensionTable(this CardInfo card)
     {
-        return ExtensionProperties.GetOrCreateValue(card).StringMap;
+        return CardExtensionProperties.GetOrCreateValue(card).StringMap;
     }
 
     private const string ERROR = "ERROR";
@@ -345,7 +345,7 @@ public static class CardManager
     private static void ClonePostfix(CardInfo __instance, object __result)
     {
         // just ensures that clones of a card have the same extension properties
-        ExtensionProperties.Add((CardInfo)__result, ExtensionProperties.GetOrCreateValue(__instance));
+        CardExtensionProperties.Add((CardInfo)__result, CardExtensionProperties.GetOrCreateValue(__instance));
     }
 
     [HarmonyILManipulator]


### PR DESCRIPTION
- Added ExtendedProperties for abilities
- Added new ability setter SetTriggersOncePerStack for controlling the behaviour of stackable abilities after a card evolves
- Added new helper methods for creating cards: SetOnePerDeck, SetHideStats
- Added new helper methods for abilities: SetCanStack, SetTriggersOncePerStack, SetActivated, SetPassive, SetConduit, SetConduitCell
- Added new remover methods for cards: RemoveAbilities, RemoveAbilitiesSingle, RemoveTraits, RemoveTribes
- Grammar fixes for existing helper method descriptions