### PR TITLE
Tribe follow-up fix, refactoring

### DIFF
--- a/InscryptionAPI/InscryptionAPIPlugin.cs
+++ b/InscryptionAPI/InscryptionAPIPlugin.cs
@@ -89,7 +89,7 @@ public class InscryptionAPIPlugin : BaseUnityPlugin
         if (outdatedPlugins != "")
             Logger.LogWarning("The following mods have been flagged as using an outdated version of the API:\n"
                 + outdatedPlugins
-                + "\nOutdated mods may not work correctly, so please update or disable them if problems arise.");
+                + "\nOutdated mods may not work correctly, so please update or disable them if problems arise!");
     }
 
     private void Awake()

--- a/InscryptionAPI/InscryptionAPIPlugin.cs
+++ b/InscryptionAPI/InscryptionAPIPlugin.cs
@@ -81,11 +81,15 @@ public class InscryptionAPIPlugin : BaseUnityPlugin
         {
             foreach (var refAsm in pluginAsm.GetReferencedAssemblies())
                 if (refAsm.Name.Equals("API"))
+                {
                     outdatedPlugins += $" - {pluginAsm.GetName().Name}\n";
+                    continue;
+                }
         }
-        Logger.LogWarning("The following plugins have been flagged as using an outdated version of the API:\n"
-            + outdatedPlugins
-            + "\nAn attempt has been made to ensure they still work, but it isn't perfect so please update or disable them if problems arise.");
+        if (outdatedPlugins != "")
+            Logger.LogWarning("The following mods have been flagged as using an outdated version of the API:\n"
+                + outdatedPlugins
+                + "\nOutdated mods may not work correctly, so please update or disable them if problems arise.");
     }
 
     private void Awake()

--- a/InscryptionAPI/Totems/TotemManager.cs
+++ b/InscryptionAPI/Totems/TotemManager.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections.ObjectModel;
+using System.Collections.ObjectModel;
 using System.Reflection;
 using System.Reflection.Emit;
 using DiskCardGame;
@@ -83,15 +83,18 @@ public static class TotemManager
         public static void AddCustomTribesToList(List<Tribe> list)
         {
             // get a list of all cards with a tribe
-            List<CardInfo> cards = CardManager.AllCardsCopy.FindAll(x => x.tribes.Count > 0);
+            List<CardInfo> tribedCards = CardManager.AllCardsCopy.FindAll(x => x.tribes.Count > 0);
 
             // iterate across all custom tribes that are obtainable as tribe choices
             foreach (TribeManager.TribeInfo tribeInfo in TribeManager.NewTribes.Where(x => x.tribeChoice))
             {
                 // Only add if we have at least 1 card of it
-                if (cards.Exists(ci => ci.tribes.Contains(tribeInfo.tribe)))
+                if (tribedCards.Exists(ci => ci.IsOfTribe(tribeInfo.tribe)))
                     list.Add(tribeInfo.tribe);
             }
+
+            // remove tribes without any cards
+            list.RemoveAll(x => !tribedCards.Exists(ci => ci.IsOfTribe(x)));
         }
     }
 

--- a/InscryptionCommunityPatch/Card/Act1LatchAbilityFix.cs
+++ b/InscryptionCommunityPatch/Card/Act1LatchAbilityFix.cs
@@ -1,9 +1,7 @@
-using System.Collections;
 using DiskCardGame;
-using GBC;
 using HarmonyLib;
-using InscryptionAPI.Card;
 using Pixelplacement;
+using System.Collections;
 using UnityEngine;
 
 namespace InscryptionCommunityPatch.Card;

--- a/InscryptionCommunityPatch/Card/Act2LogSpamFixes.cs
+++ b/InscryptionCommunityPatch/Card/Act2LogSpamFixes.cs
@@ -1,9 +1,8 @@
-using System.Collections;
 using DiskCardGame;
-using HarmonyLib;
-using System.Reflection;
-using UnityEngine;
 using GBC;
+using HarmonyLib;
+using System.Collections;
+using UnityEngine;
 
 namespace InscryptionCommunityPatch.Card;
 
@@ -55,7 +54,7 @@ internal class Act2LogSpamFixes
         Singleton<PlayerHand>.Instance.PlayingLocked = true;
         if (__instance.SpecialSequencer != null)
             yield return __instance.SpecialSequencer.PreBoardSetup();
-        
+
         yield return new WaitForSeconds(0.15f);
         yield return Singleton<LifeManager>.Instance.Initialize(__instance.SpecialSequencer == null || __instance.SpecialSequencer.ShowScalesOnStart);
         __instance.StartCoroutine(Singleton<BoardManager>.Instance.Initialize());
@@ -65,16 +64,16 @@ internal class Act2LogSpamFixes
         __instance.StartCoroutine(__instance.PlacePreSetCards(encounterData));
         if (__instance.SpecialSequencer != null)
             yield return __instance.SpecialSequencer.PreDeckSetup();
-        
+
         Singleton<PlayerHand>.Instance.Initialize();
         yield return Singleton<CardDrawPiles>.Instance.Initialize();
         if (__instance.SpecialSequencer != null)
             yield return __instance.SpecialSequencer.PreHandDraw();
-        
+
         yield return Singleton<CardDrawPiles>.Instance.DrawOpeningHand(__instance.GetFixedHand());
         if (__instance.opponent.QueueFirstCardBeforePlayer)
             yield return __instance.opponent.QueueNewCards(doTween: true, changeView: false);
-        
+
         __instance.IsSetupPhase = false;
         yield break;
     }
@@ -157,11 +156,11 @@ internal class Act2LogSpamFixes
         __instance.choosingSlotCard = card;
         if (card != null && card.Anim != null)
             card.Anim.SetSelectedToPlay(selected: true);
-        
+
         Singleton<BoardManager>.Instance.ShowCardNearBoard(card, showNearBoard: true);
         if (Singleton<TurnManager>.Instance.SpecialSequencer != null)
             yield return Singleton<TurnManager>.Instance.SpecialSequencer.CardSelectedFromHand(card);
-        
+
         bool cardWasPlayed = false;
         bool requiresSacrifices = card.Info.BloodCost > 0;
         if (requiresSacrifices)
@@ -181,18 +180,18 @@ internal class Act2LogSpamFixes
                 yield return __instance.PlayCardOnSlot(card, lastSelectedSlot);
                 if (card.Info.BonesCost > 0)
                     yield return Singleton<ResourcesManager>.Instance.SpendBones(card.Info.BonesCost);
-                
+
                 if (card.EnergyCost > 0)
                     yield return Singleton<ResourcesManager>.Instance.SpendEnergy(card.EnergyCost);
             }
         }
         if (!cardWasPlayed)
             Singleton<BoardManager>.Instance.ShowCardNearBoard(card, showNearBoard: false);
-        
+
         __instance.choosingSlotCard = null;
         if (card != null && card.Anim != null)
             card.Anim.SetSelectedToPlay(selected: false);
-        
+
         __instance.CardsInHand.ForEach(delegate (PlayableCard x)
         {
             x.SetEnabled(enabled: true);
@@ -226,7 +225,7 @@ internal class Act2LogSpamFixes
                 __instance.PlayerDamage += damage;
             else
                 __instance.OpponentDamage += damage;
-            
+
             yield return new WaitForSeconds(waitAfter);
         }
         yield break;

--- a/InscryptionCommunityPatch/Card/ActivatedAbilityHandler3D.cs
+++ b/InscryptionCommunityPatch/Card/ActivatedAbilityHandler3D.cs
@@ -6,7 +6,7 @@ namespace InscryptionCommunityPatch.Card;
 public class ActivatedAbilityHandler3D : ManagedBehaviour
 {
     public List<AbilityIconInteractable> currentIconGroup;
-    
+
     public List<ActivatedAbilityIconInteractable> interactables = new();
 
     public void AddInteractable(ActivatedAbilityIconInteractable interactable)
@@ -44,7 +44,7 @@ public class ActivatedAbilityHandler3D : ManagedBehaviour
 
     public void OnDestroy()
     {
-        foreach(var interactable in interactables)
+        foreach (var interactable in interactables)
         {
             Destroy(interactable);
         }

--- a/InscryptionCommunityPatch/Card/AdditionalIcons.cs
+++ b/InscryptionCommunityPatch/Card/AdditionalIcons.cs
@@ -1,5 +1,5 @@
-using HarmonyLib;
 using DiskCardGame;
+using HarmonyLib;
 using UnityEngine;
 
 namespace InscryptionCommunityPatch.Card;
@@ -18,14 +18,14 @@ internal class RenderAdditionalSigils
             }
 
             Transform result = Find(child, target);
-            if (result != null) 
+            if (result != null)
             {
                 return result;
-            }  
+            }
         }
         return null;
     }
-    
+
     private static void AddQuadrupleIconSlotToCard(Transform abilityIconParent)
     {
         //PLugin.Log.LogInfo($"Ability icon parent: {abilityIconParent}");
@@ -200,7 +200,7 @@ internal class RenderAdditionalSigils
             //PLugin.Log.LogInfo($"Making fourth icon");
             GameObject fourthIcon = GameObject.Instantiate(icons[0].gameObject, sixAbilities.transform);
             fourthIcon.name = "AbilityIcon";
-            fourthIcon.transform.localPosition = new Vector3(0f, -.07f, 0f); 
+            fourthIcon.transform.localPosition = new Vector3(0f, -.07f, 0f);
             fourthIcon.transform.localScale = icons[1].localScale;
 
             //PLugin.Log.LogInfo($"Making fifth icon");
@@ -265,19 +265,19 @@ internal class RenderAdditionalSigils
             //PLugin.Log.LogInfo($"Making third icon");
             GameObject thirdIcon = GameObject.Instantiate(icons[0].gameObject, sevenAbilities.transform);
             thirdIcon.name = "AbilityIcon";
-            thirdIcon.transform.localPosition = new Vector3(-0.175f, .063f, 0f); 
+            thirdIcon.transform.localPosition = new Vector3(-0.175f, .063f, 0f);
             thirdIcon.transform.localScale = icons[1].localScale;
 
             //PLugin.Log.LogInfo($"Making fourth icon");
             GameObject fourthIcon = GameObject.Instantiate(icons[0].gameObject, sevenAbilities.transform);
             fourthIcon.name = "AbilityIcon";
-            fourthIcon.transform.localPosition = new Vector3(-0.066875f, -.06f, 0f); 
+            fourthIcon.transform.localPosition = new Vector3(-0.066875f, -.06f, 0f);
             fourthIcon.transform.localScale = icons[1].localScale;
 
             //PLugin.Log.LogInfo($"Making fifth icon");
             GameObject fifthIcon = GameObject.Instantiate(icons[0].gameObject, sevenAbilities.transform);
             fifthIcon.name = "AbilityIcon";
-            fifthIcon.transform.localPosition = new Vector3(0.066875f, -.06f, 0f); 
+            fifthIcon.transform.localPosition = new Vector3(0.066875f, -.06f, 0f);
             fifthIcon.transform.localScale = icons[1].localScale;
 
             //PLugin.Log.LogInfo($"Making sixth icon");
@@ -348,25 +348,25 @@ internal class RenderAdditionalSigils
             //PLugin.Log.LogInfo($"Making fourth icon");
             GameObject fourthIcon = GameObject.Instantiate(icons[0].gameObject, eightAbilities.transform);
             fourthIcon.name = "AbilityIcon";
-            fourthIcon.transform.localPosition = new Vector3(0.200625f, .063f, 0f); 
+            fourthIcon.transform.localPosition = new Vector3(0.200625f, .063f, 0f);
             fourthIcon.transform.localScale = icons[1].localScale;
 
             //PLugin.Log.LogInfo($"Making fifth icon");
             GameObject fifthIcon = GameObject.Instantiate(icons[0].gameObject, eightAbilities.transform);
             fifthIcon.name = "AbilityIcon";
-            fifthIcon.transform.localPosition = new Vector3(-0.066875f, -.06f, 0f); 
+            fifthIcon.transform.localPosition = new Vector3(-0.066875f, -.06f, 0f);
             fifthIcon.transform.localScale = icons[1].localScale;
 
             //PLugin.Log.LogInfo($"Making sixth icon");
             GameObject sixthIcon = GameObject.Instantiate(icons[0].gameObject, eightAbilities.transform);
             sixthIcon.name = "AbilityIcon";
-            sixthIcon.transform.localPosition = new Vector3(0.066875f, -.06f, 0f); 
+            sixthIcon.transform.localPosition = new Vector3(0.066875f, -.06f, 0f);
             sixthIcon.transform.localScale = icons[1].localScale;
 
             //PLugin.Log.LogInfo($"Making seventh icon");
             GameObject seventhIcon = GameObject.Instantiate(icons[0].gameObject, eightAbilities.transform);
             seventhIcon.name = "AbilityIcon";
-            seventhIcon.transform.localPosition = new Vector3(-0.200625f, -.067f, 0f); 
+            seventhIcon.transform.localPosition = new Vector3(-0.200625f, -.067f, 0f);
             seventhIcon.transform.localScale = icons[1].localScale;
 
             //PLugin.Log.LogInfo($"Making eighth icon");

--- a/InscryptionCommunityPatch/Card/AllStrikeAbilityFix.cs
+++ b/InscryptionCommunityPatch/Card/AllStrikeAbilityFix.cs
@@ -1,8 +1,5 @@
-using System.Collections;
-using System.Collections.Generic;
 using DiskCardGame;
 using HarmonyLib;
-using UnityEngine;
 using System.Reflection;
 using System.Reflection.Emit;
 
@@ -27,9 +24,7 @@ public class AllStrikeAbilityFix
                 {
                     // start at the first ldc.i4.0
                     if (codes[j].opcode == OpCodes.Ldc_I4_0)
-                    {
                         startIndex = j;
-                    }
 
                     // end at the first break
                     if (codes[j].opcode == OpCodes.Br)

--- a/InscryptionCommunityPatch/Card/ArtPatches.cs
+++ b/InscryptionCommunityPatch/Card/ArtPatches.cs
@@ -29,7 +29,7 @@ public static class CommunityArtPatches
         Ability.SquirrelStrafe
     };
 
-    internal static readonly List<Ability> gbcIconsToPatch = new() 
+    internal static readonly List<Ability> gbcIconsToPatch = new()
     {
         Ability.ConduitSpawnGems,
         Ability.LatchBrittle,
@@ -64,10 +64,10 @@ public static class CommunityArtPatches
 
     public static void PatchCommunityArt()
     {
-        foreach(Ability ability in regularIconsToPatch)
+        foreach (Ability ability in regularIconsToPatch)
             AbilityManager.BaseGameAbilities.AbilityByID(ability).SetIcon(TextureHelper.GetImageAsTexture($"{ability.ToString()}.png", typeof(CommunityArtPatches).Assembly));
 
-        foreach(Ability ability in gbcIconsToPatch)
+        foreach (Ability ability in gbcIconsToPatch)
             AbilityManager.BaseGameAbilities.AbilityByID(ability).Info.SetPixelAbilityIcon(TextureHelper.GetImageAsTexture($"Pixel{ability.ToString()}.png", typeof(CommunityArtPatches).Assembly));
     }
 }

--- a/InscryptionCommunityPatch/Card/GreenGemStatIconFix.cs
+++ b/InscryptionCommunityPatch/Card/GreenGemStatIconFix.cs
@@ -1,7 +1,7 @@
 ﻿using DiskCardGame;
 using HarmonyLib;
-using UnityEngine;
 using InscryptionAPI.Helpers;
+using UnityEngine;
 
 namespace InscryptionCommunityPatch.Card;
 
@@ -16,7 +16,7 @@ public static class GreenGemStatIconFix
     private static void StatIconInfo_LoadAbilityData()
     {
         StatIconInfo greenGemStatIcon = StatIconInfo.allIconInfo.Find((a) => a.name == "GreenGemsStatIcon");
-        
+
         Texture2D baseTexture = TextureHelper.GetImageAsTexture("GreenGem.png", typeof(GreenGemStatIconFix).Assembly);
         greenGemStatIcon.iconGraphic = baseTexture;
         greenGemStatIcon.rulebookDescription = "The power of this card is equal to the number of Green Gems that the owner has on their side of the table.";

--- a/InscryptionCommunityPatch/Card/MergedSigilOnBottom.cs
+++ b/InscryptionCommunityPatch/Card/MergedSigilOnBottom.cs
@@ -17,37 +17,37 @@ public class MergedSigilOnBottom
     // color but without the little patch texture behind it.
 
     [HarmonyPatch(typeof(CardAbilityIcons), nameof(CardAbilityIcons.ApplyAbilitiesToIcons))]
-	[HarmonyPrefix]
-    private static bool DontPlaceCardModIcons_IfShowOnBottom(CardAbilityIcons __instance, List<AbilityIconInteractable> icons,Material iconMat)
-	{
-		// If we are showing card modifications sigils on the bottom, we don't allow the
-		// AppyAbilitiesToIcons method to do anything
-		if (iconMat == __instance.emissiveIconMat && PatchPlugin.configMergeOnBottom.Value && PatchPlugin.configRemovePatches.Value)
+    [HarmonyPrefix]
+    private static bool DontPlaceCardModIcons_IfShowOnBottom(CardAbilityIcons __instance, List<AbilityIconInteractable> icons, Material iconMat)
+    {
+        // If we are showing card modifications sigils on the bottom, we don't allow the
+        // AppyAbilitiesToIcons method to do anything
+        if (iconMat == __instance.emissiveIconMat && PatchPlugin.configMergeOnBottom.Value && PatchPlugin.configRemovePatches.Value)
         {
             foreach (var icon in icons)
                 icon.gameObject.SetActive(false);
-			return false;
+            return false;
         }
-		
-		return true;
-	}
 
-	[HarmonyPatch(typeof(CardAbilityIcons), nameof(CardAbilityIcons.PositionModIcons))]
-	[HarmonyPrefix]
+        return true;
+    }
+
+    [HarmonyPatch(typeof(CardAbilityIcons), nameof(CardAbilityIcons.PositionModIcons))]
+    [HarmonyPrefix]
     private static void MoveMergeIconsToDefaultGroup_IfShowOnBottom(List<Ability> defaultAbilities, List<Ability> mergeAbilities)
-	{
-		// This is the first time that the default abilities list is used once it has been built
-		// What we want to do is take all of the abilities from the merge group and move them to the default group
-		// if the "show merged icons on bottom" setting is active.
+    {
+        // This is the first time that the default abilities list is used once it has been built
+        // What we want to do is take all of the abilities from the merge group and move them to the default group
+        // if the "show merged icons on bottom" setting is active.
 
-		if (PatchPlugin.configMergeOnBottom.Value)
-		{
-			defaultAbilities.AddRange(mergeAbilities);
+        if (PatchPlugin.configMergeOnBottom.Value)
+        {
+            defaultAbilities.AddRange(mergeAbilities);
 
             if (PatchPlugin.configRemovePatches.Value)
-			    mergeAbilities.Clear();
-		}
-	}
+                mergeAbilities.Clear();
+        }
+    }
 
     // Token: 0x060000D0 RID: 208 RVA: 0x00004C0C File Offset: 0x00002E0C
     [HarmonyPatch(typeof(AbilityIconInteractable), "LoadIcon")]
@@ -70,7 +70,7 @@ public class MergedSigilOnBottom
                         if (mod.abilities.Contains(ability.ability) && (__instance.name == "AbilityIcon" || __instance.name == "DefaultIcons_1Ability"))
                         {
                             if (PatchPlugin.configRemovePatches.Value)
-                            { 
+                            {
                                 __instance.SetMaterial(Singleton<CardAbilityIcons>.Instance.totemIconMat);
                                 if (__instance.GetComponentInParent<MeshRenderer>() != null)
                                 {
@@ -90,7 +90,7 @@ public class MergedSigilOnBottom
                                 {
                                     allChildren = __instance.transform.parent.GetComponentsInChildren<Transform>();
                                 }
-                                
+
                                 foreach (Transform child in allChildren)
                                 {
                                     if (child.gameObject.activeSelf && child.gameObject.name.StartsWith("CardMergeIcon_"))

--- a/InscryptionCommunityPatch/Card/MissingSquirrelTribeIconFix.cs
+++ b/InscryptionCommunityPatch/Card/MissingSquirrelTribeIconFix.cs
@@ -1,9 +1,8 @@
-using System.Reflection;
-using System.Reflection.Emit;
 using DiskCardGame;
 using HarmonyLib;
 using InscryptionAPI.Helpers;
-using InscryptionAPI.Pelts;
+using System.Reflection;
+using System.Reflection.Emit;
 using UnityEngine;
 
 namespace InscryptionCommunityPatch.Card;
@@ -25,14 +24,14 @@ public class MissingSquirrelTribeIconFix
             });
         }
     }
-    
+
     [HarmonyPatch(typeof(CardDisplayer3D), nameof(CardDisplayer3D.UpdateTribeIcon))]
     private class CardDisplayer3D_UpdateTribeIcon
     {
         public static IEnumerable<CodeInstruction> Transpiler(IEnumerable<CodeInstruction> instructions)
         {
             // === We want to turn this
-            
+
             /* for (int i = 0; i < 7; i++)
 			    {
 			        if (info.IsOfTribe((Tribe)i))
@@ -41,9 +40,9 @@ public class MissingSquirrelTribeIconFix
                     }                
                 }
             */
-            
+
             // === Into this
-            
+
             /* for (int i = 0; i < 7; i++)
 			    {
 			        if (!ShowTribeOnCard(info, (Tribe)i)
@@ -52,12 +51,12 @@ public class MissingSquirrelTribeIconFix
                     }                
                 }
             */
-            
-            MethodInfo ShowTribeOnCardInfo =  SymbolExtensions.GetMethodInfo(() => ShowTribeOnCard(null, Tribe.Squirrel));
-            MethodInfo IsOfTribeInfo = AccessTools.Method(typeof(CardInfo), "IsOfTribe", new Type[] { typeof(Tribe)});
-            
+
+            MethodInfo ShowTribeOnCardInfo = SymbolExtensions.GetMethodInfo(() => ShowTribeOnCard(null, Tribe.Squirrel));
+            MethodInfo IsOfTribeInfo = AccessTools.Method(typeof(CardInfo), "IsOfTribe", new Type[] { typeof(Tribe) });
+
             // ===
-            
+
             List<CodeInstruction> codes = new List<CodeInstruction>(instructions);
             for (int i = 0; i < codes.Count; i++)
             {
@@ -72,7 +71,7 @@ public class MissingSquirrelTribeIconFix
 
             return codes;
         }
-        
+
         private static bool ShowTribeOnCard(CardInfo info, Tribe tribe)
         {
             if (!info.IsOfTribe(tribe))

--- a/InscryptionCommunityPatch/Card/Part1CardCostRender.cs
+++ b/InscryptionCommunityPatch/Card/Part1CardCostRender.cs
@@ -8,110 +8,110 @@ namespace InscryptionCommunityPatch.Card;
 [HarmonyPatch]
 public static class Part1CardCostRender
 {
-	// This patches the way card costs are rendered in Act 1 (Leshy's cabin)
-	// It allows mixed card costs to display correctly (i.e., 2 blood, 1 bone)
-	// And allows gem cost and energy cost to render on the card at all.
+    // This patches the way card costs are rendered in Act 1 (Leshy's cabin)
+    // It allows mixed card costs to display correctly (i.e., 2 blood, 1 bone)
+    // And allows gem cost and energy cost to render on the card at all.
 
-	public static event Action<CardInfo, List<Texture2D>> UpdateCardCost;
+    public static event Action<CardInfo, List<Texture2D>> UpdateCardCost;
 
-	private static Dictionary<string, Texture2D> AssembledTextures = new();
+    private static Dictionary<string, Texture2D> AssembledTextures = new();
 
-	public const int COST_OFFSET = 28;
+    public const int COST_OFFSET = 28;
 
-	public const int MOX_OFFSET = 21;
+    public const int MOX_OFFSET = 21;
 
-	public static Texture2D CombineCostTextures(List<Texture2D> costs)
-	{
-		while (costs.Count < 4)
-			costs.Add(null);
-		Texture2D baseTexture = TextureHelper.GetImageAsTexture("empty_cost.png", typeof(Part1CardCostRender).Assembly);
-		return TextureHelper.CombineTextures(costs, baseTexture, yStep:COST_OFFSET);
-	}
+    public static Texture2D CombineCostTextures(List<Texture2D> costs)
+    {
+        while (costs.Count < 4)
+            costs.Add(null);
+        Texture2D baseTexture = TextureHelper.GetImageAsTexture("empty_cost.png", typeof(Part1CardCostRender).Assembly);
+        return TextureHelper.CombineTextures(costs, baseTexture, yStep: COST_OFFSET);
+    }
 
-	public static Texture2D CombineMoxTextures(List<Texture2D> costs)
-	{
-		Texture2D baseTexture = TextureHelper.GetImageAsTexture("mox_cost_empty.png", typeof(Part1CardCostRender).Assembly);
-		return TextureHelper.CombineTextures(costs, baseTexture, xStep:MOX_OFFSET);
-	}	
+    public static Texture2D CombineMoxTextures(List<Texture2D> costs)
+    {
+        Texture2D baseTexture = TextureHelper.GetImageAsTexture("mox_cost_empty.png", typeof(Part1CardCostRender).Assembly);
+        return TextureHelper.CombineTextures(costs, baseTexture, xStep: MOX_OFFSET);
+    }
 
-	private static Texture2D GetTextureByName(string key)
-	{
-		if (AssembledTextures.ContainsKey(key))
-		{
-			if (AssembledTextures[key] != null)
-				return AssembledTextures[key];
+    private static Texture2D GetTextureByName(string key)
+    {
+        if (AssembledTextures.ContainsKey(key))
+        {
+            if (AssembledTextures[key] != null)
+                return AssembledTextures[key];
 
-			AssembledTextures.Remove(key);
-		}
+            AssembledTextures.Remove(key);
+        }
 
-		Texture2D texture = TextureHelper.GetImageAsTexture($"{key}.png", typeof(Part1CardCostRender).Assembly);
-		AssembledTextures.Add(key, texture);
-		return texture;
-	}
+        Texture2D texture = TextureHelper.GetImageAsTexture($"{key}.png", typeof(Part1CardCostRender).Assembly);
+        AssembledTextures.Add(key, texture);
+        return texture;
+    }
 
-	internal static string GemCost(CardInfo info)
-	{
-		return (info.GemsCost.Contains(GemType.Orange) ? "o": string.Empty) + 
-			   (info.GemsCost.Contains(GemType.Blue) ? "b": string.Empty) + 
-			   (info.GemsCost.Contains(GemType.Green) ? "g": string.Empty);
-	}
+    internal static string GemCost(CardInfo info)
+    {
+        return (info.GemsCost.Contains(GemType.Orange) ? "o" : string.Empty) +
+               (info.GemsCost.Contains(GemType.Blue) ? "b" : string.Empty) +
+               (info.GemsCost.Contains(GemType.Green) ? "g" : string.Empty);
+    }
 
-	public static Sprite Part1SpriteFinal(CardInfo card)
-	{
-		// A list to hold the textures (important later, to combine them all)
-		List<Texture2D> list = new List<Texture2D>();
+    public static Sprite Part1SpriteFinal(CardInfo card)
+    {
+        // A list to hold the textures (important later, to combine them all)
+        List<Texture2D> list = new List<Texture2D>();
 
-		//Setting mox first
-		if (card.gemsCost.Count > 0)
-		{
-			//make a new list for the mox textures
-			List<Texture2D> gemCost = new List<Texture2D>();
+        //Setting mox first
+        if (card.gemsCost.Count > 0)
+        {
+            //make a new list for the mox textures
+            List<Texture2D> gemCost = new List<Texture2D>();
 
-			//load up the mox textures as "empty"
-			Texture2D orange = GetTextureByName(card.GemsCost.Contains(GemType.Orange) ? "mox_cost_o" : "mox_cost_e");
-			Texture2D blue = GetTextureByName(card.GemsCost.Contains(GemType.Blue) ? "mox_cost_b" : "mox_cost_e");
-			Texture2D green = GetTextureByName(card.GemsCost.Contains(GemType.Green) ? "mox_cost_g" : "mox_cost_e");
-			
-			//Add all moxes to the gemcost list
-			gemCost.Add(orange);
-			gemCost.Add(green);
-			gemCost.Add(blue);
+            //load up the mox textures as "empty"
+            Texture2D orange = GetTextureByName(card.GemsCost.Contains(GemType.Orange) ? "mox_cost_o" : "mox_cost_e");
+            Texture2D blue = GetTextureByName(card.GemsCost.Contains(GemType.Blue) ? "mox_cost_b" : "mox_cost_e");
+            Texture2D green = GetTextureByName(card.GemsCost.Contains(GemType.Green) ? "mox_cost_g" : "mox_cost_e");
 
-			//Combine the textures into one
-			list.Add(CombineMoxTextures(gemCost));
-		}
+            //Add all moxes to the gemcost list
+            gemCost.Add(orange);
+            gemCost.Add(green);
+            gemCost.Add(blue);
 
-		if (card.EnergyCost > 0)
-			list.Add(GetTextureByName($"energy_cost_{card.EnergyCost}"));
+            //Combine the textures into one
+            list.Add(CombineMoxTextures(gemCost));
+        }
 
-		if (card.BonesCost > 0)
-			list.Add(GetTextureByName($"bone_cost_{card.BonesCost}"));
+        if (card.EnergyCost > 0)
+            list.Add(GetTextureByName($"energy_cost_{card.EnergyCost}"));
 
-		if (card.BloodCost > 0)
-			list.Add(GetTextureByName($"blood_cost_{card.BloodCost}"));
+        if (card.BonesCost > 0)
+            list.Add(GetTextureByName($"bone_cost_{card.BonesCost}"));
 
-		// Call the event and allow others to modify the list of textures
-		UpdateCardCost?.Invoke(card, list);
+        if (card.BloodCost > 0)
+            list.Add(GetTextureByName($"blood_cost_{card.BloodCost}"));
 
-		// Combine all the textures from the list into one texture
-		Texture2D finalTexture = CombineCostTextures(list);
+        // Call the event and allow others to modify the list of textures
+        UpdateCardCost?.Invoke(card, list);
 
-		// Convert the final texture to a sprite
-		return TextureHelper.ConvertTexture(finalTexture, TextureHelper.SpriteType.OversizedCostDecal);
-	}
+        // Combine all the textures from the list into one texture
+        Texture2D finalTexture = CombineCostTextures(list);
 
-	[HarmonyPatch(typeof(CardDisplayer), nameof(CardDisplayer.GetCostSpriteForCard))]
-	[HarmonyPrefix]
+        // Convert the final texture to a sprite
+        return TextureHelper.ConvertTexture(finalTexture, TextureHelper.SpriteType.OversizedCostDecal);
+    }
+
+    [HarmonyPatch(typeof(CardDisplayer), nameof(CardDisplayer.GetCostSpriteForCard))]
+    [HarmonyPrefix]
     private static bool Part1CardCostDisplayerPatch(ref Sprite __result, ref CardInfo card, ref CardDisplayer __instance)
-	{	
-		//Make sure we are in Leshy's Cabin
-		if (__instance is CardDisplayer3D && SceneLoader.ActiveSceneName.StartsWith("Part1")) 
-		{ 
-			/// Set the results as the new sprite
-			__result = Part1SpriteFinal(card);
-			return false;
-		}
+    {
+        //Make sure we are in Leshy's Cabin
+        if (__instance is CardDisplayer3D && SceneLoader.ActiveSceneName.StartsWith("Part1"))
+        {
+            /// Set the results as the new sprite
+            __result = Part1SpriteFinal(card);
+            return false;
+        }
 
-		return true;
-	}
+        return true;
+    }
 }

--- a/InscryptionCommunityPatch/Card/Part1SniperVisualizer.cs
+++ b/InscryptionCommunityPatch/Card/Part1SniperVisualizer.cs
@@ -1,9 +1,6 @@
-using System;
-using System.Collections.Generic;
-using System.Text;
 using DiskCardGame;
-using UnityEngine;
 using Pixelplacement;
+using UnityEngine;
 
 namespace InscryptionCommunityPatch.Card;
 internal class Part1SniperVisualizer : ManagedBehaviour

--- a/InscryptionCommunityPatch/Card/Part2CardCostRender.cs
+++ b/InscryptionCommunityPatch/Card/Part2CardCostRender.cs
@@ -1,8 +1,8 @@
 using DiskCardGame;
-using UnityEngine;
+using GBC;
 using HarmonyLib;
 using InscryptionAPI.Helpers;
-using GBC;
+using UnityEngine;
 
 namespace InscryptionCommunityPatch.Card;
 
@@ -10,8 +10,8 @@ namespace InscryptionCommunityPatch.Card;
 public static class Part2CardCostRender
 {
     // This patches the way card costs are rendered in Act 2 (GBC)
-	// It allows mixed card costs to display correctly (i.e., 2 blood, 1 bone)
-	// And makes the card costs take up a smaller amount of space on the card, showing off more art.
+    // It allows mixed card costs to display correctly (i.e., 2 blood, 1 bone)
+    // And makes the card costs take up a smaller amount of space on the card, showing off more art.
     // Also allows for custom costs to hook in and be displayed without the creator needing to patch cost render
 
     public static event Action<CardInfo, List<Texture2D>> UpdateCardCost;
@@ -26,7 +26,7 @@ public static class Part2CardCostRender
         List<Texture2D> list = new List<Texture2D>();
         if (cardCost <= 4)
         {
-            for (int i = 0; i < cardCost; i ++)
+            for (int i = 0; i < cardCost; i++)
                 list.Add(artCost);
         }
         else
@@ -36,7 +36,7 @@ public static class Part2CardCostRender
         }
 
         int xOffset = left ? 0 : cardCost >= 10 ? 30 - 20 - artCost.width : cardCost <= 4 ? 30 - artCost.width * cardCost : 30 - 14 - artCost.width;
-        return TextureHelper.CombineTextures(list, baseTexture, xOffset:xOffset, xStep:artCost.width);
+        return TextureHelper.CombineTextures(list, baseTexture, xOffset: xOffset, xStep: artCost.width);
     }
 
     public static Sprite Part2SpriteFinal(CardInfo card)
@@ -47,14 +47,14 @@ public static class Part2CardCostRender
         List<Texture2D> masterList = new List<Texture2D>();
 
         if (card.BloodCost > 0)
-            masterList.Add(CombineIconAndCount(card.BloodCost, TextureHelper.GetImageAsTexture("pixel_blood.png", typeof(Part2CardCostRender).Assembly))); 
+            masterList.Add(CombineIconAndCount(card.BloodCost, TextureHelper.GetImageAsTexture("pixel_blood.png", typeof(Part2CardCostRender).Assembly)));
 
         if (card.BonesCost > 0)
             masterList.Add(CombineIconAndCount(card.BonesCost, TextureHelper.GetImageAsTexture("pixel_bone.png", typeof(Part2CardCostRender).Assembly)));
 
         if (card.EnergyCost > 0)
             masterList.Add(CombineIconAndCount(card.EnergyCost, TextureHelper.GetImageAsTexture("pixel_energy.png", typeof(Part2CardCostRender).Assembly)));
-        
+
         if (card.gemsCost.Count > 0)
         {
             List<Texture2D> gemCost = new List<Texture2D>();
@@ -74,18 +74,18 @@ public static class Part2CardCostRender
             if (!left)
                 gemCost.Reverse();
 
-            masterList.Add(TextureHelper.CombineTextures(gemCost, gemBaseTexture, xOffset:left ? 0 : 30 - 7 * gemCost.Count, xStep:7));
+            masterList.Add(TextureHelper.CombineTextures(gemCost, gemBaseTexture, xOffset: left ? 0 : 30 - 7 * gemCost.Count, xStep: 7));
         }
 
         // Call the event and allow others to modify the list of textures
-		UpdateCardCost?.Invoke(card, masterList);
+        UpdateCardCost?.Invoke(card, masterList);
 
         while (masterList.Count < 4)
             masterList.Add(null);
 
         //Combine all the textures from the list into one texture
         Texture2D baseTexture = TextureHelper.GetImageAsTexture("pixel_base.png", typeof(Part2CardCostRender).Assembly);
-        Texture2D finalTexture = TextureHelper.CombineTextures(masterList, baseTexture, yStep:8);
+        Texture2D finalTexture = TextureHelper.CombineTextures(masterList, baseTexture, yStep: 8);
 
         //Convert the final texture to a sprite
         Sprite finalSprite = TextureHelper.ConvertTexture(finalTexture, left ? TextureHelper.SpriteType.Act2CostDecalLeft : TextureHelper.SpriteType.Act2CostDecalRight);
@@ -93,17 +93,17 @@ public static class Part2CardCostRender
     }
 
     [HarmonyPatch(typeof(CardDisplayer), nameof(CardDisplayer.GetCostSpriteForCard))]
-	[HarmonyPrefix]
+    [HarmonyPrefix]
     private static bool Part2CardCostDisplayerPatch(ref Sprite __result, ref CardInfo card, ref CardDisplayer __instance)
-	{	
-		//Make sure we are only modifying pixel cards
-		if (__instance is PixelCardDisplayer && PatchPlugin.act2CostRender.Value) 
-		{ 
-			/// Set the results as the new sprite
-			__result = Part2SpriteFinal(card);
-			return false;
-		}
+    {
+        //Make sure we are only modifying pixel cards
+        if (__instance is PixelCardDisplayer && PatchPlugin.act2CostRender.Value)
+        {
+            /// Set the results as the new sprite
+            __result = Part2SpriteFinal(card);
+            return false;
+        }
 
-		return true;
-	}
+        return true;
+    }
 }

--- a/InscryptionCommunityPatch/Card/Part3StatIcons.cs
+++ b/InscryptionCommunityPatch/Card/Part3StatIcons.cs
@@ -118,7 +118,7 @@ internal static class Part3StatIcons
                             gem == GemType.Orange ? Ability.GainGemOrange :
                             Ability.GainGemBlue;
 
-        return BoardManager.Instance.OpponentSlotsCopy.Any(slot => 
+        return BoardManager.Instance.OpponentSlotsCopy.Any(slot =>
             slot.Card != null && (
                 slot.Card.HasAbility(singleton) ||
                 slot.Card.HasAbility(Ability.GainGemTriple)
@@ -140,7 +140,7 @@ internal static class Part3StatIcons
 
                 bool show = (__instance.PlayableCard.OpponentCard && OpponentHasGem(target)) ||
                             (!__instance.PlayableCard.OpponentCard && ResourcesManager.Instance.HasGem(target));
-                
+
                 __instance.gemsPropertyBlock.SetColor("_EmissionColor", show ? Color.white : Color.black);
                 __instance.gemRenderers[i].SetPropertyBlock(__instance.gemsPropertyBlock);
             }

--- a/InscryptionCommunityPatch/Card/PassiveAttackBuffPatches.cs
+++ b/InscryptionCommunityPatch/Card/PassiveAttackBuffPatches.cs
@@ -1,4 +1,3 @@
-using System.Collections;
 using DiskCardGame;
 using HarmonyLib;
 using InscryptionAPI.Card;
@@ -55,7 +54,7 @@ public static class PassiveAttackBuffPatches
                 foreach (CardSlot slot in BoardManager.Instance.GetSlots(__instance.OpponentCard).Where(slot => slot.Card))
                 {
                     __result += slot.Card.AbilityCount(Ability.BuffEnemy);
-                    if(__instance.LacksAbility(Ability.MadeOfStone))
+                    if (__instance.LacksAbility(Ability.MadeOfStone))
                     {
                         __result -= slot.Card.AbilityCount(Ability.DebuffEnemy);
                     }
@@ -64,7 +63,7 @@ public static class PassiveAttackBuffPatches
             else if (__instance.HasOpposingCard())
             {
                 __result += __instance.OpposingCard().AbilityCount(Ability.BuffEnemy);
-                if(__instance.LacksAbility(Ability.MadeOfStone))
+                if (__instance.LacksAbility(Ability.MadeOfStone))
                 {
                     __result -= __instance.OpposingCard().AbilityCount(Ability.DebuffEnemy);
                 }
@@ -93,7 +92,7 @@ public static class PassiveAttackBuffPatches
 
             if (__instance.OpponentCard && BoardManager.Instance.OpponentSlotsCopy.Any(c => c.Card != null && (c.Card.HasAbility(Ability.GainGemOrange) || c.Card.HasAbility(Ability.GainGemTriple))))
                 __result += 1;
-        }   
+        }
 
         return false;
     }

--- a/InscryptionCommunityPatch/Card/SacrificeTokensFix.cs
+++ b/InscryptionCommunityPatch/Card/SacrificeTokensFix.cs
@@ -22,6 +22,7 @@ public static class SacrificeTokensFix
                 for (int i = 0; i < amountOfNewTokens; i++)
                 {
                     SacrificeToken token = SacrificeToken.Instantiate(__instance.tokens.tokens[i]);
+                    token.transform.SetParent(__instance.tokens.tokens[0].transform.parent);
                     __instance.tokens.tokens.Add(token);
                 }
             }

--- a/InscryptionCommunityPatch/Card/SelfAttackDamagePatch.cs
+++ b/InscryptionCommunityPatch/Card/SelfAttackDamagePatch.cs
@@ -16,7 +16,6 @@ public class SelfAttackDamagePatch
     private const string name_PlayerAttacker = "System.Boolean playerIsAttacker";
     private const string name_SpecialSequencer = "DiskCardGame.SpecialBattleSequencer specialSequencer";
     private const string name_SquirrelAttacker = "System.Boolean <attackedWithSquirrel>5__4";
-    private const string name_CombatState = "System.Int32 <>1__state";
     private const string name_CombatCurrent = "System.Object <>2__current";
 
     // Get the method MoveNext, which is where the actual code for SlotAttackSlot is located
@@ -50,8 +49,6 @@ public class SelfAttackDamagePatch
             object op_PlayerAttacker = null;
             object op_SpecialSequencer = null;
             object op_SquirrelAttacker = null;
-            object op_CombatState = null;
-            object op_CombatCurrent = null;
 
             // get everything we need
             for (int j = i - 1; j < codes.Count; j++)

--- a/InscryptionCommunityPatch/Card/SentryInteractionFixes.cs
+++ b/InscryptionCommunityPatch/Card/SentryInteractionFixes.cs
@@ -1,12 +1,11 @@
-using System.Collections;
 using DiskCardGame;
 using HarmonyLib;
+using System.Collections;
 using UnityEngine;
 
 namespace InscryptionCommunityPatch.Card;
 
-// Fixes a few issues relating to Sentry interacting with certain Act 1 abilities / mechanics
-[HarmonyPatch]
+[HarmonyPatch] // Fixes a few issues relating to Sentry interacting with certain Act 1 abilities / mechanics
 public class SentryInteractionFixes
 {
     // Fixes a soft crash that occurs when the enemy totem tries to perform its check OnAssignedToSlot

--- a/InscryptionCommunityPatch/Card/SentryPackMuleFixes.cs
+++ b/InscryptionCommunityPatch/Card/SentryPackMuleFixes.cs
@@ -1,9 +1,9 @@
-using System.Collections;
 using DiskCardGame;
 using HarmonyLib;
-using UnityEngine;
 using Pixelplacement;
 using Pixelplacement.TweenSystem;
+using System.Collections;
+using UnityEngine;
 
 namespace InscryptionCommunityPatch.Card;
 
@@ -14,7 +14,7 @@ internal class SentryPackMuleFixes
     // Prevents the logic for opening the pack from running if the pack object is null
     [HarmonyPatch(typeof(PackMule), nameof(PackMule.SpawnAndOpenPack))]
     [HarmonyPrefix]
-    public static bool FixPackMuleBreakingRealityOnDeath(Transform pack)
+    private static bool FixPackMuleBreakingRealityOnDeath(Transform pack)
     {
         if (pack == null)
             return false;
@@ -24,7 +24,7 @@ internal class SentryPackMuleFixes
 
     [HarmonyPatch(typeof(PackMule), nameof(PackMule.OnDie))]
     [HarmonyPostfix]
-    public static IEnumerator FixPackNotExisting(IEnumerator enumerator, PackMule __instance)
+    private static IEnumerator FixPackNotExisting(IEnumerator enumerator, PackMule __instance)
     {
         if (__instance.pack == null)
         {
@@ -52,7 +52,7 @@ internal class SentryPackMuleFixes
     // (prevents a minor visual glitch)
     [HarmonyPatch(typeof(PackMule), nameof(PackMule.OnResolveOnBoard))]
     [HarmonyPrefix]
-    public static bool FixPackMuleVisualGlitch(PackMule __instance)
+    private static bool FixPackMuleVisualGlitch(PackMule __instance)
     {
         if (__instance.PlayableCard.Dead)
             return false;

--- a/InscryptionCommunityPatch/Card/SentryTailOnHitFix.cs
+++ b/InscryptionCommunityPatch/Card/SentryTailOnHitFix.cs
@@ -1,6 +1,6 @@
-using System.Collections;
 using DiskCardGame;
 using HarmonyLib;
+using System.Collections;
 using UnityEngine;
 
 namespace InscryptionCommunityPatch.Card;

--- a/InscryptionCommunityPatch/Card/SniperFix.cs
+++ b/InscryptionCommunityPatch/Card/SniperFix.cs
@@ -1,9 +1,6 @@
-using System;
-using System.Collections;
-using System.Collections.Generic;
-using System.Text;
 using DiskCardGame;
 using HarmonyLib;
+using System.Collections;
 using UnityEngine;
 
 namespace InscryptionCommunityPatch.Card;
@@ -15,7 +12,7 @@ public class SniperFix
     [HarmonyPrefix]
     public static bool MaybeOverrideAttack(CombatPhaseManager __instance, ref IEnumerator __result, CardSlot slot)
     {
-        if(slot?.Card != null && slot.Card.HasAbility(Ability.Sniper))
+        if (slot?.Card != null && slot.Card.HasAbility(Ability.Sniper))
         {
             __result = SniperAttack(__instance, slot);
             return false;

--- a/InscryptionCommunityPatch/Card/StackAbilityIcons.cs
+++ b/InscryptionCommunityPatch/Card/StackAbilityIcons.cs
@@ -45,7 +45,7 @@ public static class StackAbilityIcons
             stackGBC = "stack_gbc_alt.png";
         }
         Texture2D texture = TextureHelper.GetImageAsTexture(stackGBC, typeof(StackAbilityIcons).Assembly);
-        return Sprite.Create(texture, new Rect(0f, 10f * (9f-number), 15f, 10f), new Vector2(0.5f, 0.5f));
+        return Sprite.Create(texture, new Rect(0f, 10f * (9f - number), 15f, 10f), new Vector2(0.5f, 0.5f));
     }
 
     private static Sprite[] GBC_NUMBER_SPRITES = new Sprite[]
@@ -142,8 +142,8 @@ public static class StackAbilityIcons
                                 failed = true;
                                 break;
                             }
-                        } 
-                        else 
+                        }
+                        else
                         {
                             if (searchPixels[i].a > 0)
                             {
@@ -248,7 +248,7 @@ public static class StackAbilityIcons
     {
         // https://support.unity.com/hc/en-us/articles/206486626-How-can-I-get-pixels-from-unreadable-textures-
         // Create a temporary RenderTexture of the same size as the texture
-        RenderTexture tmp = RenderTexture.GetTemporary( 
+        RenderTexture tmp = RenderTexture.GetTemporary(
                             texture.width,
                             texture.height,
                             0,
@@ -304,7 +304,7 @@ public static class StackAbilityIcons
             newTexture.SetPixels(patchLocation.x - 1, patchLocation.y + 1, TOP_BORDER.Length, 1, TOP_BORDER, 0);
             newTexture.SetPixels(patchLocation.x - 1, patchLocation.y + 1, 1, LEFT_BORDER.Length, LEFT_BORDER, 0);
         }
-        
+
         // Set the new number
         Texture2D newNumber = (textureType == NORMAL) ? NUMBER_TEXTURES[count - 1] : MEDIUM_NUMBER_TEXTURES[count - 1];
         newTexture.SetPixels(patchLocation.x, patchLocation.y, newNumber.width, newNumber.height, newNumber.GetPixels(), 0);
@@ -332,14 +332,14 @@ public static class StackAbilityIcons
         // Here's the goal
         // Find all abilities on the card
         // Replace all of the textures where it stacks with a texture showing that it stacks
-        
+
         // PatchPlugin.Logger.LogDebug("Adding new icon; testing for stacks");
 
         // Okay, go through each ability on the card and see how many instances it has.
         List<Ability> baseAbilities = info.Abilities;
         if (card != null)
             baseAbilities.AddRange(AbilitiesUtil.GetAbilitiesFromMods(card.TemporaryMods));
-        
+
         int count = baseAbilities.Where(ab => ab == ability).Count();
 
         if (count > 1)
@@ -350,7 +350,7 @@ public static class StackAbilityIcons
         }
     }
 
-    [HarmonyPatch(typeof(PixelCardAbilityIcons), "DisplayAbilities", new Type[] { typeof(List<Ability>), typeof(PlayableCard)})]
+    [HarmonyPatch(typeof(PixelCardAbilityIcons), "DisplayAbilities", new Type[] { typeof(List<Ability>), typeof(PlayableCard) })]
     [HarmonyPrefix]
     private static bool PatchPixelCardStacks(ref PixelCardAbilityIcons __instance, List<Ability> abilities, PlayableCard card)
     {
@@ -363,7 +363,7 @@ public static class StackAbilityIcons
         {
             foreach (GameObject gameObject in abilityIconGroups)
                 gameObject.gameObject.SetActive(false);
-            
+
             if (grps.Count > 0 && grps.Count - 1 < abilityIconGroups.Count)
             {
                 GameObject iconGroup = abilityIconGroups[grps.Count - 1];
@@ -399,7 +399,7 @@ public static class StackAbilityIcons
                     if (countTransform == null && grps[i].Item2 <= 1)
                         continue;
 
-//InfiniscryptionStackableSigilsPlugin.Log.LogInfo($"countTransform {countTransform}");
+                    //InfiniscryptionStackableSigilsPlugin.Log.LogInfo($"countTransform {countTransform}");
                     if (countTransform == null)
                     {
                         GameObject counter = new GameObject();
@@ -453,7 +453,7 @@ public static class StackAbilityIcons
         int duplicateCount = 0;
         for (int i = 1; i < lines.Length; i++)
         {
-            if (lines[i] == lines[i-1])
+            if (lines[i] == lines[i - 1])
             {
                 duplicateCount += 1;
             }
@@ -465,10 +465,10 @@ public static class StackAbilityIcons
                 duplicateCount = 0;
             }
         }
-        if (duplicateCount > 0 )
+        if (duplicateCount > 0)
         {
             retval = retval + $" (x{duplicateCount + 1})";
-        } 
+        }
         return retval;
     }
 
@@ -476,6 +476,6 @@ public static class StackAbilityIcons
     [HarmonyPostfix]
     private static void GetStackedGBCDescriptionLocalized(ref string __result)
     {
-        __result = StackDescription(__result);        
+        __result = StackDescription(__result);
     }
 }

--- a/InscryptionCommunityPatch/InscryptionCommunityPatchPlugin.cs
+++ b/InscryptionCommunityPatch/InscryptionCommunityPatchPlugin.cs
@@ -66,15 +66,15 @@ public class PatchPlugin : BaseUnityPlugin
     private void Awake()
     {
         Instance = this;
-        configEnergy = Config.Bind("Energy","Energy Refresh",true,"Max energy increases and energy refreshes at end of turn");
-        configDrone = Config.Bind("Energy","Energy Drone",false,"Drone is visible to display energy (requires Energy Refresh)");
-        configMox = Config.Bind("Mox","Mox Refresh",true,"Mox refreshes at end of battle");
-        configDroneMox = Config.Bind("Mox","Mox Drone",false,"Drone displays mox (requires Energy Drone and Mox Refresh)");
-        configShowSquirrelTribeOnCards = Config.Bind("Tribes","Show Squirrel Tribe",false,"Shows the Squirrel tribe icon on cards");
+        configEnergy = Config.Bind("Energy", "Energy Refresh", true, "Max energy increases and energy refreshes at end of turn");
+        configDrone = Config.Bind("Energy", "Energy Drone", false, "Drone is visible to display energy (requires Energy Refresh)");
+        configMox = Config.Bind("Mox", "Mox Refresh", true, "Mox refreshes at end of battle");
+        configDroneMox = Config.Bind("Mox", "Mox Drone", false, "Drone displays mox (requires Energy Drone and Mox Refresh)");
+        configShowSquirrelTribeOnCards = Config.Bind("Tribes", "Show Squirrel Tribe", false, "Shows the Squirrel tribe icon on cards");
         act2CostRender = Config.Bind("Card Costs", "GBC Cost render", true, "GBC Cards are able to display custom costs and hybrid costs through the API.");
-        rightAct2Cost = Config.Bind("Card Costs","GBC Cost On Right",true,"GBC Cards display their costs on the top-right corner. If false, display on the top-left corner");
+        rightAct2Cost = Config.Bind("Card Costs", "GBC Cost On Right", true, "GBC Cards display their costs on the top-right corner. If false, display on the top-left corner");
         configMergeOnBottom = Config.Bind("Sigil Display", "Merge_On_Botom", false, "Makes it so if enabled, merged sigils will display on the bottom of the card instead of on the artwork. In extreme cases, this can cause some visual bugs.");
-		configRemovePatches = Config.Bind("Sigil Display", "Remove_Patches", false, "Makes it so if enabled, merged sigils will not have a patch behind them anymore and will instead be glowing yellow (only works with Merge_On_Bottom).");
+        configRemovePatches = Config.Bind("Sigil Display", "Remove_Patches", false, "Makes it so if enabled, merged sigils will not have a patch behind them anymore and will instead be glowing yellow (only works with Merge_On_Bottom).");
         act2StackIconType = Config.Bind("Sigil Display", "Act 2 Sigil icon type", true, "If true, stacking icons are a cream outline with a black center. If false, stacking icons are a black outline with a cream center. Act 2");
 
         configTestState = Config.Bind("General", "Test Mode", false, "Puts the game into test mode. This will cause (among potentially other things) a new run to spawn a number of cards into your opening deck that will demonstrate card behaviors.");

--- a/InscryptionCommunityPatch/ResourceManagers/ActOneEnergyDrone.cs
+++ b/InscryptionCommunityPatch/ResourceManagers/ActOneEnergyDrone.cs
@@ -1,8 +1,8 @@
-using System.Collections;
 using DiskCardGame;
 using HarmonyLib;
 using InscryptionAPI.Card;
 using Pixelplacement;
+using System.Collections;
 using UnityEngine;
 using UnityEngine.SceneManagement;
 
@@ -15,7 +15,7 @@ public static class EnergyDrone
     {
         private bool _configEnergyOverride = false;
         public bool ConfigEnergy
-        { 
+        {
             get => EnergyDrone.PoolHasEnergy || PatchPlugin.configEnergy.Value || _configEnergyOverride;
             set => _configEnergyOverride = value;
         }
@@ -29,14 +29,14 @@ public static class EnergyDrone
 
         private bool _configMoxOverride = false;
         public bool ConfigMox
-        { 
+        {
             get => EnergyDrone.PoolHasGems || PatchPlugin.configMox.Value || _configMoxOverride;
             set => _configMoxOverride = value;
         }
 
         private bool _configDroneMoxOverride = false;
         public bool ConfigDroneMox
-        { 
+        {
             get => EnergyDrone.PoolHasGems || PatchPlugin.configDroneMox.Value || _configDroneMoxOverride;
             set => _configDroneMoxOverride = value;
         }
@@ -113,7 +113,7 @@ public static class EnergyDrone
             return;
 
         // Check the entire pool of cards for mox and energy
-        CardTemple targetTemple = SaveManager.saveFile.IsGrimora ? CardTemple.Undead : 
+        CardTemple targetTemple = SaveManager.saveFile.IsGrimora ? CardTemple.Undead :
                                   SaveManager.saveFile.IsMagnificus ? CardTemple.Wizard :
                                   CardTemple.Nature;
 
@@ -138,7 +138,7 @@ public static class EnergyDrone
             ResourceDrone.Instance.Awake();
 
         yield return new WaitForSeconds(1);
-        
+
         if (ResourceDrone.Instance != null)
             ResourceDrone.Instance.AttachGemsModule();
     }
@@ -171,7 +171,7 @@ public static class EnergyDrone
                 __instance.gameObject.SetActive(value: true);
                 __instance.SetAllCellsOn(on: false);
             }
-            Tween.Position(__instance.gameObject.transform, vector,onBoard ? 0.157f : 0.27f, onBoard ? 0.0f : 0.255f,
+            Tween.Position(__instance.gameObject.transform, vector, onBoard ? 0.157f : 0.27f, onBoard ? 0.0f : 0.255f,
                 onBoard ? Tween.EaseInOut : Tween.EaseOut, Tween.LoopType.None, null, delegate
             {
                 if (onBoard)
@@ -320,17 +320,17 @@ public static class EnergyDrone
             if (showEnergyModule)
             {
                 ViewManager.Instance.SwitchToView(View.Default, false, true);
-			    yield return new WaitForSeconds(0.1f);
+                yield return new WaitForSeconds(0.1f);
             }
 
             yield return ResourcesManager.Instance.AddMaxEnergy(1);
-		    yield return ResourcesManager.Instance.RefreshEnergy();
+            yield return ResourcesManager.Instance.RefreshEnergy();
 
             if (showEnergyModule)
             {
                 yield return new WaitForSeconds(0.25f);
-			    Singleton<ViewManager>.Instance.Controller.LockState = ViewLockState.Unlocked;
+                Singleton<ViewManager>.Instance.Controller.LockState = ViewLockState.Unlocked;
             }
         }
-	}
+    }
 }

--- a/InscryptionCommunityPatch/Sequencers/CardCostChoiceNodePatchers.cs
+++ b/InscryptionCommunityPatch/Sequencers/CardCostChoiceNodePatchers.cs
@@ -1,8 +1,8 @@
-using System.Collections;
 using DiskCardGame;
-using UnityEngine;
 using HarmonyLib;
 using InscryptionAPI.Helpers;
+using System.Collections;
+using UnityEngine;
 
 namespace InscryptionCommunityPatch.Sequencers;
 
@@ -34,7 +34,7 @@ internal static class ChoiceNodePatch
 
         if (GetRandomChoosableMoxCard(randomSeed++) != null)
             __result.Add(new CardChoice() { resourceType = ResourceType.Gems });
-        
+
         while (list.Count > 3)
             list.RemoveAt(SeededRandom.Range(0, list.Count, randomSeed++));
 
@@ -51,18 +51,18 @@ internal static class ChoiceNodePatch
             CardInfo cardInfo = new CardInfo();
             if (card.ChoiceInfo.resourceType == ResourceType.Energy)
                 cardInfo = GetRandomChoosableEnergyCard(SaveManager.SaveFile.GetCurrentRandomSeed());
-            
+
             if (card.ChoiceInfo.resourceType == ResourceType.Gems)
                 cardInfo = GetRandomChoosableMoxCard(SaveManager.SaveFile.GetCurrentRandomSeed());
-            
+
             card.SetInfo(cardInfo);
             card.SetFaceDown(false, false);
             card.SetInteractionEnabled(false);
-            yield return __instance.TutorialTextSequence(card);		
+            yield return __instance.TutorialTextSequence(card);
             card.SetCardbackToDefault();
             yield return __instance.WaitForCardToBeTaken(card);
             yield break;
-        } 
+        }
         else
         {
             yield return enumerator;

--- a/InscryptionCommunityPatch/Sequencers/CardStatBoostSequencerPatch.cs
+++ b/InscryptionCommunityPatch/Sequencers/CardStatBoostSequencerPatch.cs
@@ -1,0 +1,174 @@
+using DiskCardGame;
+using HarmonyLib;
+using System.Collections;
+using System.Reflection;
+using System.Reflection.Emit;
+using UnityEngine;
+
+namespace InscryptionCommunityPatch.Sequencers;
+
+[HarmonyPatch]
+internal class CardStatBoostSequencerPatch
+{
+    private const string name_Current = "System.Object <>2__current";
+    private const string name_State = "System.Int32 <>1__state";
+
+    private const string name_DisplayClass = "DiskCardGame.CardStatBoostSequencer+<>c__DisplayClass12_0 <>8__1";
+    private const string name_AttackMod = "System.Boolean attackMod";
+
+    private const string name_ViewInstance = "DiskCardGame.ViewManager get_Instance()";
+
+    private const string name_GetValidCards = "System.Collections.Generic.List`1[DiskCardGame.CardInfo] GetValidCards(Boolean)";
+    private const string name_DestroyCard = "Void DestroyCard()";
+    private static MethodBase TargetMethod()
+    {
+        MethodBase baseMethod = AccessTools.Method(typeof(CardStatBoostSequencer), nameof(CardStatBoostSequencer.StatBoostSequence));
+        return AccessTools.EnumeratorMoveNext(baseMethod);
+    }
+
+    private static object Transpiler(IEnumerable<CodeInstruction> instructions)
+    {
+        List<CodeInstruction> codes = new List<CodeInstruction>(instructions);
+
+        // startIndex is where the if statement will be placed,
+        // endIndex is where the custom method will be placed
+        int startIndex = -1, endIndex = -1;
+
+        object op_Current = null;
+        object op_State = null;
+
+        object op_DisplayClass = null;
+        object op_AttackMod = null;
+
+        object op_GetValidCards = null;
+        object op_GetCount = null;
+
+        CodeInstruction instruction = null;
+
+        for (int i = 0; i < codes.Count; i++)
+        {
+            if (codes[i].opcode == OpCodes.Stfld && codes[i].operand.ToString() == name_Current && op_Current == null)
+                op_Current = codes[i].operand;
+
+            else if (codes[i].opcode == OpCodes.Stfld && codes[i].operand.ToString() == name_State && op_State == null)
+                op_State = codes[i].operand;
+
+            else if (codes[i].opcode == OpCodes.Ldfld && codes[i].operand.ToString() == name_DisplayClass && op_DisplayClass == null)
+                op_DisplayClass = codes[i].operand;
+
+            else if (codes[i].opcode == OpCodes.Ldfld && codes[i].operand.ToString() == name_AttackMod && op_AttackMod == null)
+                op_AttackMod = codes[i].operand;
+
+            else if (codes[i].opcode == OpCodes.Callvirt && codes[i].operand.ToString() == name_GetValidCards && op_GetValidCards == null)
+            {
+                op_GetValidCards = codes[i].operand;
+                op_GetCount = codes[i + 1].operand;
+            }
+            else if (codes[i].opcode == OpCodes.Ldc_I4_7)
+                startIndex = i - 6;
+
+            else if (codes[i].opcode == OpCodes.Call && codes[i].operand.ToString() == name_ViewInstance && codes[i + 1].opcode == OpCodes.Ldc_I4_1 && codes[i + 3].opcode == OpCodes.Ldc_I4_0)
+                endIndex = i + 5;
+
+            // get the CodeInstruction that skips past the bulk of the sequence
+            else if (codes[i].opcode == OpCodes.Callvirt && codes[i].operand.ToString() == name_DestroyCard)
+                instruction = new(codes[i + 1]);
+
+            if (startIndex != -1 && endIndex != -1)
+            {
+                // if (sequencer.GetValidCards(forAttackMod: attackMod).Count != 0)
+                //      vanilla sequence
+                // else
+                //      custom message
+                //      end sequence
+
+                MethodBase customMethod = AccessTools.Method(typeof(CardStatBoostSequencerPatch),
+                    nameof(CardStatBoostSequencerPatch.NewStatBoostSequence),
+                    new Type[] { typeof(CardStatBoostSequencer), typeof(bool) });
+
+                // Insert custom method before the if, since it's further down
+
+                // this.<>2__current = customMethod
+                codes.Insert(endIndex, new CodeInstruction(OpCodes.Ldarg_0));
+
+                // sequencer
+                codes.Insert(endIndex + 1, new CodeInstruction(OpCodes.Ldloc_1));
+
+                // this.<DisplayClass>.attackMod
+                codes.Insert(endIndex + 2, new CodeInstruction(OpCodes.Ldarg_0));
+                codes.Insert(endIndex + 3, new CodeInstruction(OpCodes.Ldfld, op_DisplayClass));
+                codes.Insert(endIndex + 4, new CodeInstruction(OpCodes.Ldfld, op_AttackMod));
+
+                // method, current
+                codes.Insert(endIndex + 5, new CodeInstruction(OpCodes.Callvirt, customMethod));
+                codes.Insert(endIndex + 6, new CodeInstruction(OpCodes.Stfld, op_Current));
+
+                // this.<>1__state = 66
+                codes.Insert(endIndex + 7, new CodeInstruction(OpCodes.Ldarg_0));
+                codes.Insert(endIndex + 8, new CodeInstruction(OpCodes.Ldc_I4_S, 66));
+                codes.Insert(endIndex + 9, new CodeInstruction(OpCodes.Stfld, op_State));
+
+                // return true
+                codes.Insert(endIndex + 10, new CodeInstruction(OpCodes.Ldc_I4_1));
+                codes.Insert(endIndex + 11, new CodeInstruction(OpCodes.Ret));
+
+                // if (sequencer.GetValidCards(forAttackMod: attackMod).Count != 0)
+
+                // sequencer
+                codes.Insert(startIndex, new CodeInstruction(OpCodes.Ldloc_1));
+
+                // this.<DisplayClass>.attackMod
+                codes.Insert(startIndex + 1, new CodeInstruction(OpCodes.Ldarg_0));
+                codes.Insert(startIndex + 2, new CodeInstruction(OpCodes.Ldfld, op_DisplayClass));
+                codes.Insert(startIndex + 3, new CodeInstruction(OpCodes.Ldfld, op_AttackMod));
+
+                // GetValidCards().Count
+                codes.Insert(startIndex + 4, new CodeInstruction(OpCodes.Callvirt, op_GetValidCards));
+                codes.Insert(startIndex + 5, new CodeInstruction(OpCodes.Callvirt, op_GetCount));
+
+                // else
+                codes.Insert(startIndex + 6, instruction);
+                codes[startIndex + 6].opcode = OpCodes.Brfalse_S;
+                break;
+            }
+        }
+        return codes;
+    }
+
+    private static IEnumerator NewStatBoostSequence(CardStatBoostSequencer instance, bool attackMod)
+    {
+        // if there aren't any valid cards, exit the sequence
+        if (instance.GetValidCards(forAttackMod: attackMod).Count == 0)
+        {
+            PatchPlugin.Logger.LogDebug("Player has no cards that can be boosted at the campfire.");
+            Singleton<ViewManager>.Instance.SwitchToView(View.Default);
+            yield return new WaitForSeconds(0.5f);
+            yield return Singleton<TextDisplayer>.Instance.ShowUntilInput("You have no creatures to warm.");
+            yield return new WaitForSeconds(0.5f);
+            AudioController.Instance.PlaySound3D("campfire_putout", MixerGroup.TableObjectsSFX, instance.selectionSlot.transform.position);
+            AudioController.Instance.StopLoop(1);
+            instance.campfireLight.gameObject.SetActive(value: false);
+            Singleton<ExplorableAreaManager>.Instance.HandLight.gameObject.SetActive(value: false);
+            yield return instance.pile.DestroyCards();
+            yield return new WaitForSeconds(0.2f);
+            instance.figurines.ForEach(delegate (CompositeFigurine x)
+            {
+                x.gameObject.SetActive(value: false);
+            });
+            instance.stakeRingParent.SetActive(value: false);
+            instance.confirmStone.SetStoneInactive();
+            instance.selectionSlot.gameObject.SetActive(value: false);
+            CustomCoroutine.WaitThenExecute(0.4f, delegate
+            {
+                Singleton<ExplorableAreaManager>.Instance.HangingLight.intensity = 0f;
+                Singleton<ExplorableAreaManager>.Instance.HangingLight.gameObject.SetActive(value: true);
+                Singleton<ExplorableAreaManager>.Instance.HandLight.intensity = 0f;
+                Singleton<ExplorableAreaManager>.Instance.HandLight.gameObject.SetActive(value: true);
+            });
+
+            ProgressionData.SetMechanicLearned(MechanicsConcept.CardStatBoost);
+            if (Singleton<GameFlowManager>.Instance != null)
+                Singleton<GameFlowManager>.Instance.TransitionToGameState(GameState.Map);
+        }
+    }
+}

--- a/InscryptionCommunityPatch/Sequencers/PackRatNodeBackgroundFix.cs
+++ b/InscryptionCommunityPatch/Sequencers/PackRatNodeBackgroundFix.cs
@@ -1,9 +1,7 @@
 using DiskCardGame;
 using HarmonyLib;
-using InscryptionCommunityPatch.Card;
 using System.Reflection;
 using System.Reflection.Emit;
-using UnityEngine;
 
 namespace InscryptionCommunityPatch.Sequencers;
 

--- a/InscryptionCommunityPatch/Tests/TestBoons.cs
+++ b/InscryptionCommunityPatch/Tests/TestBoons.cs
@@ -1,6 +1,6 @@
-using System.Collections;
 using DiskCardGame;
 using InscryptionAPI.Boons;
+using System.Collections;
 
 namespace InscryptionCommunityPatch.Tests;
 

--- a/InscryptionCommunityPatch/Tests/TestCommunityPatches.cs
+++ b/InscryptionCommunityPatch/Tests/TestCommunityPatches.cs
@@ -1,7 +1,7 @@
-using HarmonyLib;
 using DiskCardGame;
-using InscryptionAPI.Card;
+using HarmonyLib;
 using InscryptionAPI.Boons;
+using InscryptionAPI.Card;
 using UnityEngine;
 
 namespace InscryptionCommunityPatch.Tests;
@@ -18,7 +18,7 @@ public static class ExecuteCommunityPatchTests
         AbilityManager.BaseGameAbilities.AbilityByID(Ability.RandomConsumable).Info.canStack = true;
 
         // Creates a boon
-        TestBoon = BoonManager.New(PatchPlugin.ModGUID, "Sacrificial Squirrels", typeof(SacrificeSquirrels), 
+        TestBoon = BoonManager.New(PatchPlugin.ModGUID, "Sacrificial Squirrels", typeof(SacrificeSquirrels),
         "Squirrels are super OP now", Resources.Load<Texture2D>("art/cards/abilityicons/ability_drawcopyondeath"),
         Resources.Load<Texture2D>("art/cards/boons/boonportraits/boon_startinggoat"), false, true, true);
     }


### PR DESCRIPTION
Tribal choice and totem choice nodes will no longer offer vanilla tribes that have no associated cards (tribal choice node considers obtainable cards while totem choice considers all cards).

Tribal choice node no longer softlocks if there are less than 3 valid tribes to draw cards from.

Campfire node no longer softlocks if you have no cards that can be boosted.

Refactored community patches; cleaned up usings, fixed inconsistent spacing, privated methods in SentryPackMule patch