### PR TITLE
Hotfix/spawn objects logging

### DIFF
--- a/InscryptionAPI/Encounters/OpponentManager.cs
+++ b/InscryptionAPI/Encounters/OpponentManager.cs
@@ -164,17 +164,15 @@ public static class OpponentManager
 
             // nodeData = new BossBattleNodeData();
             // (nodeData as BossBattleNodeData).bossType = RunState.CurrentMapRegion.bosses[Random.Range(0, RunState.CurrentMapRegion.bosses.Count)];
-            // (nodeData as BossBattleNodeData).specialBattleId = BossBattleSequencer.GetSequencerIdForBoss((nodeData as BossBattleNodeData).bossType);
 
             // === Into this
 
             // nodeData = new BossBattleNodeData();
             // (nodeData as BossBattleNodeData).bossType = RunState.CurrentMapRegion.bosses[Random.Range(0, RunState.CurrentMapRegion.bosses.Count)];
             // ProcessBossType(nodeData);
-            // (nodeData as BossBattleNodeData).specialBattleId = BossBattleSequencer.GetSequencerIdForBoss((nodeData as BossBattleNodeData).bossType);
 
             // ===
-            FieldInfo cardPileField = AccessTools.Field(typeof(BossBattleNodeData), "bossType");
+            FieldInfo bossTypeField = AccessTools.Field(typeof(BossBattleNodeData), "bossType");
             
             List<CodeInstruction> codes = new List<CodeInstruction>(instructions);
             for (int i = 0; i < codes.Count; i++)
@@ -182,7 +180,7 @@ public static class OpponentManager
                 CodeInstruction codeInstruction = codes[i];
                 if (codeInstruction.opcode == OpCodes.Stfld)
                 {
-                    if (codeInstruction.operand == cardPileField)
+                    if (codeInstruction.operand == bossTypeField)
                     {
                         codes.Insert(++i, new CodeInstruction(OpCodes.Ldloc_0));
                         codes.Insert(++i, new CodeInstruction(OpCodes.Call, ProcessMethodInfo));
@@ -199,8 +197,25 @@ public static class OpponentManager
             BossBattleNodeData bossBattleNodeData = (BossBattleNodeData)nodeData;
 
             // Parse data
-            string value = ModdedSaveManager.RunState.GetValue(InscryptionAPIPlugin.ModGUID, "PreviousBosses");
-            List<int> previousBosses= new List<int>(); // 2,0,1
+            List<Opponent.Type> bosses = RunStateOpponents;
+            if(bosses.Count == 0)
+            {
+                bosses.Add(Opponent.Type.ProspectorBoss);
+                bosses.Add(Opponent.Type.AnglerBoss);
+                bosses.Add(Opponent.Type.TrapperTraderBoss);
+            }
+            
+            bossBattleNodeData.bossType = bosses[RunState.CurrentRegionTier];
+        }
+    }
+
+    public static List<Opponent.Type> RunStateOpponents
+    {
+        get
+        {
+            List<Opponent.Type> previousBosses = new List<Opponent.Type>();
+
+            string value = ModdedSaveManager.RunState.GetValue(InscryptionAPIPlugin.ModGUID, "PreviousBosses"); // 2,0,1
             if (value == null)
             {
                 // Do nothing
@@ -208,43 +223,32 @@ public static class OpponentManager
             else if (!value.Contains(','))
             {
                 // Single boss encounter
-                previousBosses.Add(int.Parse(value));
+                previousBosses.Add((Opponent.Type)int.Parse(value));
             }
             else
             {
                 // Multiple boss encounters
-                IEnumerable<int> ids = value.Split(',').Select(int.Parse);
+                IEnumerable<Opponent.Type> ids = value.Split(',').Select(static (a) => (Opponent.Type)int.Parse(a));
                 previousBosses.AddRange(ids);
             }
-            
-            // We have already seen this boss. Choose another if we can!
-            if (previousBosses.Contains((int)bossBattleNodeData.bossType))
-            {
-                List<Opponent.Type> availableBosses = new List<Opponent.Type>(RunState.CurrentMapRegion.bosses);
-                availableBosses.RemoveAll((a)=>previousBosses.Contains((int)a));
-                if (availableBosses.Count > 0)
-                {
-                    // Replace boss if we have at least 1
-                    bossBattleNodeData.bossType = availableBosses[UnityEngine.Random.Range(0, availableBosses.Count)];
-                }
-            }
-            
-            // Add boss
-            previousBosses.Add((int)bossBattleNodeData.bossType);
 
-            // Save boss
+            return previousBosses;
+        }
+        set
+        {
             string result = ""; // 2,0,1
-            for (int i = 0; i < previousBosses.Count; i++)
+            for (int i = 0; i < value.Count; i++)
             {
                 if (i > 0)
                 {
                     result += ",";
                 }
-                result += (int)previousBosses[i];
+                result += (int)value[i];
 
             }
             ModdedSaveManager.RunState.SetValue(InscryptionAPIPlugin.ModGUID, "PreviousBosses", result);
         }
     }
+
     #endregion
 }

--- a/InscryptionAPI/Helpers/Extensions/ListExtensions.cs
+++ b/InscryptionAPI/Helpers/Extensions/ListExtensions.cs
@@ -7,6 +7,20 @@ namespace InscryptionAPI.Helpers.Extensions;
 
 public static class ListExtensions
 {
+    public static T PopFirst<T>(this List<T> list)
+    {
+        T t = list[0];
+        list.RemoveAt(0);
+        return t;
+    }
+    
+    public static T PopLast<T>(this List<T> list)
+    {
+        T t = list[list.Count - 1];
+        list.RemoveAt(list.Count - 1);
+        return t;
+    }
+    
     public static List<T> Repeat<T>(this T toRepeat, int times)
     {
         List<T> repeated = new();
@@ -18,6 +32,12 @@ public static class ListExtensions
             }
         }
         return repeated;
+    }
+    
+    public static T GetRandom<T>(this List<T> list)
+    {
+        int index = UnityEngine.Random.Range(0, list.Count);
+        return list[index];
     }
     
     public static T GetSeededRandom<T>(this List<T> list, int seed)

--- a/InscryptionAPI/Helpers/TranspilerHelpers.cs
+++ b/InscryptionAPI/Helpers/TranspilerHelpers.cs
@@ -1,0 +1,17 @@
+﻿using HarmonyLib;
+
+namespace InscryptionAPI.Helpers;
+
+public static class TranspilerHelpers
+{
+    public static void LogCodeInscryptions(List<CodeInstruction> codes, string prefix = null)
+    {
+        string p = prefix == null ? "" : prefix;
+        for (int i = 0; i < codes.Count; i++)
+        {
+            CodeInstruction code = codes[i];
+            string codeOperand = code.operand == null ? "" : code.operand.ToString();
+            InscryptionAPIPlugin.Logger.LogInfo($"{p}{i}: {code.opcode} {codeOperand}");
+        }
+    }
+}

--- a/InscryptionAPI/Saves/ModdedSaveManager.cs
+++ b/InscryptionAPI/Saves/ModdedSaveManager.cs
@@ -77,7 +77,7 @@ public static class ModdedSaveManager
     }
 
     [HarmonyPatch(typeof(AscensionSaveData), "NewRun")]
-    [HarmonyPostfix]
+    [HarmonyPrefix]
     private static void ResetRunStateOnNewAscensionRun()
     {
         RunState = new();


### PR DESCRIPTION
Refactored how regions are created so they don't have double ups of bosses.
Refactored how regions so the save stores an index to the list of all regions instead of whatever it was doing before.
Refactored how opponents are chosen on map creation so there are no double ups of bosses
Added descriptive error log when a card has an ability and a card errors trying to show it.
Added descriptive error log when getting a card by name that doesn't exist
Added descriptive error log when generating a new map and a prop doesn't exist