### PR TITLE
Fixed regions appearing out-of-order in Act 1

### DIFF
--- a/InscryptionAPI/Regions/RegionManager.cs
+++ b/InscryptionAPI/Regions/RegionManager.cs
@@ -13,7 +13,7 @@ namespace InscryptionAPI.Regions;
 [HarmonyPatch]
 public static class RegionManager
 {
-    public static readonly ReadOnlyCollection<RegionData> BaseGameRegions = new(GetOrderedBaseRegions());
+    public static readonly ReadOnlyCollection<RegionData> BaseGameRegions = new(ReorderBaseRegions());
 
     /* Order of BaseGameRegions before reordering
      * !TEST_PART3
@@ -25,7 +25,7 @@ public static class RegionManager
      * Wetlands
      */
 
-    private static List<RegionData> GetOrderedBaseRegions()
+    private static List<RegionData> ReorderBaseRegions()
     {
         List<RegionData> baseRegions = Resources.LoadAll<RegionData>("Data").ToList();
         List<RegionData> orderedRegions = new()

--- a/InscryptionAPI/Regions/RegionManager.cs
+++ b/InscryptionAPI/Regions/RegionManager.cs
@@ -13,7 +13,29 @@ namespace InscryptionAPI.Regions;
 [HarmonyPatch]
 public static class RegionManager
 {
-    public static readonly ReadOnlyCollection<RegionData> BaseGameRegions = new(Resources.LoadAll<RegionData>("Data"));
+    public static readonly ReadOnlyCollection<RegionData> BaseGameRegions = new(GetOrderedBaseRegions());
+
+    /* Order of BaseGameRegions before reordering
+     * !TEST_PART3
+     * Alpine
+     * Forest
+     * Midnight
+     * Midnight_Ascension
+     * Pirateville
+     * Wetlands
+     */
+
+    private static List<RegionData> GetOrderedBaseRegions()
+    {
+        List<RegionData> baseRegions = Resources.LoadAll<RegionData>("Data").ToList();
+        List<RegionData> orderedRegions = new()
+        {
+            baseRegions[2], baseRegions[6], baseRegions[1],
+            baseRegions[3], baseRegions[4], baseRegions[5], baseRegions[0]
+        };
+
+        return orderedRegions;
+    }
     private static readonly ObservableCollection<Part1RegionData> NewRegions = new();
 
     public static event Func<List<RegionData>, List<RegionData>> ModifyRegionsList;
@@ -35,7 +57,7 @@ public static class RegionManager
 
     private static RegionData CloneRegion(this RegionData data)
     {
-        RegionData retval = (RegionData)UnityEngine.Object.Internal_CloneSingle(data);
+        RegionData retval = (RegionData)UnityObject.Internal_CloneSingle(data);
         retval.name = data.name;
         return retval;
     }
@@ -65,9 +87,7 @@ public static class RegionManager
         InscryptionAPIPlugin.ScriptableObjectLoaderLoad += static type =>
         {
             if (type == typeof(RegionData))
-            {
                 ScriptableObjectLoader<RegionData>.allData = AllRegionsCopy;
-            }
         };
         NewRegions.CollectionChanged += static (_, _) =>
         {
@@ -80,9 +100,7 @@ public static class RegionManager
     public static void Add(RegionData newRegion, int tier)
     {
         if (!NewRegions.Select(x => x.Region).Contains(newRegion))
-        {
             NewRegions.Add(new Part1RegionData(newRegion, tier));
-        }
     }
     public static void Remove(RegionData region) => NewRegions.Remove(NewRegions.Where(x => x.Region == region).First());
 
@@ -103,7 +121,7 @@ public static class RegionManager
     public static RegionData FromTierFull(string name, int originalTier, int newTier, bool addToPool = true)
     {
         RegionProgression copy = ResourceBank.Get<RegionProgression>("Data/Map/RegionProgression");
-        RegionData retval = (RegionData)RegionData.Internal_CloneSingle(copy.regions[originalTier]);
+        RegionData retval = (RegionData)UnityObject.Internal_CloneSingle(copy.regions[originalTier]);
         retval.name = name;
 
         if (addToPool)
@@ -144,7 +162,7 @@ public static class RegionManager
     {
         return FromTierBasic(name, originalTier, originalTier, addToPool);
     }
-    
+
     #region Patches
     [HarmonyPrefix]
     [HarmonyPatch(typeof(RunState), "CurrentMapRegion", MethodType.Getter)]
@@ -155,22 +173,30 @@ public static class RegionManager
             __result = ResourceBank.Get<RegionData>("Data/Map/Regions/!TEST_PART3");
             return false;
         }
-        
+
+        foreach (var i in RunState.Run.regionOrder)
+            InscryptionAPIPlugin.Logger.LogInfo("1: " + i);
+
+        InscryptionAPIPlugin.Logger.LogInfo("2: " + RunState.Run.regionTier);
+
         if (SaveFile.IsAscension)
         {
+            // InscryptionAPIPlugin.Logger.LogInfo(RunState.Run.regionOrder[RunState.Run.regionTier]);
             if (RunState.Run.regionTier == RegionProgression.Instance.regions.Count - 1)
             {
                 if (AscensionSaveData.Data.ChallengeIsActive(AscensionChallenge.FinalBoss))
                     __result = RegionProgression.Instance.ascensionFinalBossRegion;
                 else
                     __result = RegionProgression.Instance.ascensionFinalRegion;
+
                 return false;
             }
             __result = AllRegionsCopy[RunState.Run.regionOrder[RunState.Run.regionTier]];
             return false;
         }
-        
+
         __result = AllRegionsCopy[RunState.Run.regionTier];
+
         return false;
     }
 
@@ -193,13 +219,10 @@ public static class RegionManager
                 {
                     terrainIsForPlayer = SeededRandom.Bool(randomSeed++);
                     if (terrainIsForPlayer && playerTerrain == 1)
-                    {
                         terrainIsForPlayer = false;
-                    }
+
                     else if (!terrainIsForPlayer && enemyTerrain == 1)
-                    {
                         terrainIsForPlayer = true;
-                    }
                 }
                 else
                 {
@@ -212,47 +235,35 @@ public static class RegionManager
                 for (int j = 0; j < 4; j++)
                 {
                     if (sameSideSlots[j] == null && otherSideSlots[j] == null)
-                    {
                         availableSpace = true;
-                    }
                 }
                 if (!availableSpace)
-                {
                     break;
-                }
+
                 while (sameSideSlots[slotForTerrain] != null || otherSideSlots[slotForTerrain] != null)
-                {
                     slotForTerrain = SeededRandom.Range(0, sameSideSlots.Length, randomSeed++);
-                }
+
                 if (terrainIsForPlayer && reachTerrainOnPlayerSide)
                 {
                     CardInfo cardInfo = RunState.CurrentMapRegion.terrainCards.Find((CardInfo x) => x.HasAbility(Ability.Reach));
                     if (cardInfo == null && !customregion.RemoveDefaultReachTerrain)
-                    {
                         cardInfo = CardLoader.GetCardByName("Tree");
-                    }
+
                     if (cardInfo != null)
-                    {
                         sameSideSlots[slotForTerrain] = CardLoader.GetCardByName(cardInfo.name);
-                    }
                 }
                 else
                 {
                     List<CardInfo> list = RunState.CurrentMapRegion.terrainCards.FindAll((CardInfo x) => (ConceptProgressionTree.Tree.CardUnlocked(x, true) || customregion.AllowLockedTerrainCards) &&
                         (x.traits.Contains(Trait.Terrain) || customregion.AllowSacrificableTerrainCards));
                     if (list.Count > 0)
-                    {
                         sameSideSlots[slotForTerrain] = CardLoader.GetCardByName(list[SeededRandom.Range(0, list.Count, randomSeed++)].name);
-                    }
                 }
+
                 if (terrainIsForPlayer)
-                {
                     playerTerrain++;
-                }
                 else
-                {
                     enemyTerrain++;
-                }
             }
             return false;
         }
@@ -293,15 +304,12 @@ public static class RegionManager
         {
             // Props normally have the renderer on the object itself. But custom props sometimes will ot have this.
             if (gameObject.TryGetComponent(out Renderer renderer))
-            {
                 return renderer;
-            }
 
             Renderer spawnedMapObjectRenderer = gameObject.GetComponentInChildren<Renderer>();
             if (spawnedMapObjectRenderer == null)
-            {
                 InscryptionAPIPlugin.Logger.LogError($"[RegionManager] Map object {gameObject.name} does not have a renderer attached!");
-            }
+
             return spawnedMapObjectRenderer;
         }
     }
@@ -322,9 +330,7 @@ public static class RegionManager
         }
         
         if (!isScenery)
-        {
-            gameObject = UnityEngine.Object.Instantiate(original);
-        }
+            gameObject = UnityObject.Instantiate(original);
         else
         {
             MapElement mapElement = original.GetComponent<MapElement>();
@@ -352,8 +358,8 @@ public static class RegionManager
     private static List<RegionData> GetAllRegionsForMapGeneration()
     {
         List<RegionData> allRegions = new(RegionProgression.Instance.regions);
-        allRegions.RemoveAt(allRegions.Count-1); // Remove midnight region
-        allRegions.AddRange(NewRegions.Select((a)=>a.Region)); // New Regions
+        allRegions.RemoveAt(allRegions.Count - 1); // Remove midnight region
+        allRegions.AddRange(NewRegions.Select(a => a.Region)); // New Regions
         return allRegions;
     }
     
@@ -379,9 +385,7 @@ public static class RegionManager
             }
 
             if (selectedRegions.Count == 3)
-            {
                 break;
-            }
         }
 
         // Safety check: Make sure we have 3 regions!
@@ -390,20 +394,14 @@ public static class RegionManager
             List<RegionData> unusedRegions = allRegions.Where((a) => !selectedRegions.Contains(a)).ToList();
             RegionData selectedRegion = null;
             if (unusedRegions.Count == 0)
-            {
                 selectedRegion = allRegions[0];
-            }
             else
-            {
                 selectedRegion = unusedRegions[0];
-            }
             
             selectedRegions.Add(selectedRegion);
             Opponent.Type opponentType = GetRandomAvailableOpponent(selectedRegion, selectedOpponents);
             if (opponentType == Opponent.Type.Default)
-            {
                 opponentType = selectedRegion.bosses.GetRandom();
-            }
 
             selectedOpponents.Add(opponentType);
         }
@@ -434,9 +432,7 @@ public static class RegionManager
     {
         List<Opponent.Type> enumerable = regionData.bosses.Where((a) => !selectedOpponents.Contains(a)).ToList();
         if (enumerable.Count == 0)
-        {
             return Opponent.Type.Default;
-        }
 
         return enumerable.GetRandom();
     }

--- a/InscryptionAPI/Regions/RegionManager.cs
+++ b/InscryptionAPI/Regions/RegionManager.cs
@@ -174,11 +174,6 @@ public static class RegionManager
             return false;
         }
 
-        foreach (var i in RunState.Run.regionOrder)
-            InscryptionAPIPlugin.Logger.LogInfo("1: " + i);
-
-        InscryptionAPIPlugin.Logger.LogInfo("2: " + RunState.Run.regionTier);
-
         if (SaveFile.IsAscension)
         {
             // InscryptionAPIPlugin.Logger.LogInfo(RunState.Run.regionOrder[RunState.Run.regionTier]);


### PR DESCRIPTION
Rearranges the order of the vanilla game regions in RegionManager.BaseGameRegions, hopefully doesn't screw up anything.