### PR TITLE
8-sigil support for Acts 2 and 3

### DIFF
--- a/InscryptionCommunityPatch/Card/Act2LogSpamFixes.cs
+++ b/InscryptionCommunityPatch/Card/Act2LogSpamFixes.cs
@@ -93,22 +93,18 @@ internal class Act2LogSpamFixes
         __instance.GameEnding = true;
 
         if (!__instance.PlayerWon && __instance.opponent != null && __instance.opponent.Blueprint != null)
-        {
             AnalyticsManager.SendFailedEncounterEvent(__instance.opponent.Blueprint, __instance.opponent.Difficulty, __instance.TurnNumber);
-        }
+
         if (__instance.SpecialSequencer != null)
-        {
             yield return __instance.SpecialSequencer.PreCleanUp();
-        }
+
         Singleton<ViewManager>.Instance.Controller.LockState = ViewLockState.Locked;
         if (__instance.PlayerWon && __instance.PostBattleSpecialNode == null)
-        {
             Singleton<ViewManager>.Instance.SwitchToView(View.MapDefault);
-        }
+
         else
-        {
             Singleton<ViewManager>.Instance.SwitchToView(View.Default);
-        }
+
         yield return new WaitForSeconds(0.1f);
         __instance.StartCoroutine(Singleton<PlayerHand>.Instance.CleanUp());
         __instance.StartCoroutine(Singleton<CardDrawPiles>.Instance.CleanUp());
@@ -119,18 +115,12 @@ internal class Act2LogSpamFixes
 
         yield return Singleton<LifeManager>.Instance.CleanUp();
         if (__instance.SpecialSequencer != null)
-        {
             yield return __instance.SpecialSequencer.GameEnd(__instance.PlayerWon);
-        }
 
-        if (__instance.PlayerWon && SaveManager.SaveFile.IsPart3)
-        {
-            Part3SaveData.Data.IncreaseBounty(10);
-        }
-        UnityEngine.Object.Destroy(__instance.opponent.gameObject);
+        UnityObject.Destroy(__instance.opponent.gameObject);
 
         Singleton<PlayerHand>.Instance.SetShown(shown: false);
-        UnityEngine.Object.Destroy(__instance.SpecialSequencer);
+        UnityObject.Destroy(__instance.SpecialSequencer);
         yield break;
     }
 

--- a/InscryptionCommunityPatch/Card/BoxColliderNegativeScalingLogSpamFix.cs
+++ b/InscryptionCommunityPatch/Card/BoxColliderNegativeScalingLogSpamFix.cs
@@ -1,4 +1,4 @@
-﻿using DiskCardGame;
+using DiskCardGame;
 using HarmonyLib;
 using Sirenix.Utilities;
 using UnityEngine;
@@ -24,20 +24,23 @@ public class BoxColliderNegativeScalingLogSpamFix
     [HarmonyPrefix, HarmonyPatch(nameof(AbilityIconInteractable.SetFlippedY))]
     public static void ReplaceBoxColliderWithMeshColliderIfIconIsFlipped(AbilityIconInteractable __instance, bool flippedY)
     {
-        if (flippedY && __instance.gameObject.GetComponent<MeshCollider>().SafeIsUnityNull())
+        if (flippedY || SaveManager.SaveFile.IsPart3)
         {
-            MeshCollider collider = __instance.gameObject.AddComponent<MeshCollider>();
-            collider.convex = true;
-            collider.sharedMesh = null;
-            collider.sharedMesh = __instance.GetComponent<MeshFilter>().mesh;
+            if (__instance.gameObject.GetComponent<MeshCollider>().SafeIsUnityNull())
+            {
+                MeshCollider collider = __instance.gameObject.AddComponent<MeshCollider>();
+                collider.convex = true;
+                //collider.sharedMesh = null;
+                collider.sharedMesh = __instance.GetComponent<MeshFilter>().mesh;
 
-            UnityObject.Destroy(__instance.GetComponent<BoxCollider>());
-            __instance.coll = null;
-            __instance.coll = collider;
-            // This was the missing piece.
-            // The collider box when the MeshCollider is added ends up being right under the card, therefore unable to click.
-            // Adjusting the y position here to be higher up allows the icon to be right-clickable again.
-            __instance.transform.position += new Vector3(0, 0.1f, 0);
+                UnityObject.Destroy(__instance.GetComponent<BoxCollider>());
+                //__instance.coll = null;
+                __instance.coll = collider;
+                // This was the missing piece.
+                // The collider box when the MeshCollider is added ends up being right under the card, therefore unable to click.
+                // Adjusting the y position here to be higher up allows the icon to be right-clickable again.
+                __instance.transform.position += new Vector3(0, 0.1f, 0);
+            }
         }
     }
 }


### PR DESCRIPTION
Allows cards in Acts 2 and 3 to have up to 8 sigils visually displayed. Also adjusted sigil positions in Act 1 slightly.