### PR TITLE
Dynamic Cost fixes, new ResourcesManager extension method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## 2.14.3
+- Fixed Act 2 bug relating to stackable sigils and activated sigils in the deck display menu
 - Fixed dynamic costs still not working in Act 2
 - Fixed dynamic gem costs checking ResourcesManager instead of OpponentGemsManager for opponent cards
 - Fixed dynamic costs not checking for owned blue gems

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## 2.14.3
+- Fixed dynamic costs still not working in Act 2
+- Fixed dynamic gem costs checking ResourcesManager instead of OpponentGemsManager for opponent cards
+- Fixed dynamic costs not checking for owned blue gems
+- Fixed dynamic costs not updating energy display correctly
+- Changed dynamic costs to patch SetInfo instead of Awake
+- Re-added dynamic cost error messages for when the card or card info is null
+- Added ResourcesManager.Instance.GemsOfType(GemType) to check for owned gems of the specified type
+
 ## 2.14.2
 - Fixed Overclock patch not checking for the correct Acts
 - Fixed appearance behaviour's Card field always returning null in Act 2

--- a/InscryptionAPI/Card/CardExtensions.cs
+++ b/InscryptionAPI/Card/CardExtensions.cs
@@ -6,6 +6,7 @@ using System.Collections;
 using System.Reflection;
 using HarmonyLib;
 using UnityEngine;
+using Microsoft.Win32.SafeHandles;
 
 namespace InscryptionAPI.Card;
 
@@ -142,87 +143,6 @@ public static class CardExtensions
             if (!info.tribes.Contains(app))
                 info.tribes.Add(app);
         return info;
-    }
-    
-    /// <summary>
-    /// Returns the blood cost of a card.
-    /// This function can be overriden if someone wants to inject new cost into a cards blood cost
-    /// </summary>
-    public static int BloodCost(this PlayableCard card)
-    {
-        if (card && card.Info)
-        {
-            int originalBloodCost = CostProperties.CostProperties.OriginalBloodCost(card.Info);
-
-            if (IsGemified(card))
-                originalBloodCost--;
-            
-            return originalBloodCost;
-        } 
-        
-        //InscryptionAPIPlugin.Logger.LogError("[BloodCost] Couldn't find Card or CardInfo for blood cost??? How is this possible?");
-        return 0;
-    }
-    
-    
-    /// <summary>
-    /// Returns the bone cost of a card.
-    /// This function can be overriden if someone wants to inject new cost into a cards bone cost
-    /// </summary>
-    public static int BonesCost(this PlayableCard card)
-    {
-        if (card && card.Info)
-        {
-            return CostProperties.CostProperties.OriginalBonesCost(card.Info);
-        } 
-        
-        //InscryptionAPIPlugin.Logger.LogError("Couldn't find Card or CardInfo for bone cost??? How is this possible?");
-        return 0;
-    }
-    
-    
-    /// <summary>
-    /// Returns the gem cost of a card.
-    /// This function can be overriden if someone wants to inject new cost into a cards gem cost
-    /// </summary>
-    public static List<GemType> GemsCost(this PlayableCard card)
-    {
-        if (!card || !card.Info)
-            return new();
-
-        List<CardModificationInfo> mods = card.TemporaryMods.Concat(card.Info.Mods).ToList();
-        if (mods.Exists((CardModificationInfo x) => x.nullifyGemsCost))
-        {
-            return new List<GemType>();
-        }
-        
-        List<GemType> gemsCost = new(card.Info.gemsCost);
-        foreach (CardModificationInfo mod in mods)
-        {
-            if (mod.addGemCost == null)
-            {
-                continue;
-            }
-            foreach (GemType item in mod.addGemCost)
-            {
-                if (!gemsCost.Contains(item))
-                {
-                    gemsCost.Add(item);
-                }
-            }
-        }
-        
-        if (gemsCost.Count > 0 && Singleton<ResourcesManager>.Instance.HasGem(GemType.Blue) && IsGemified(card))
-        {
-            gemsCost.RemoveAt(0);
-        }
-
-        return gemsCost;
-    }
-    
-    public static bool IsGemified(this PlayableCard card)
-    {
-        return card.TemporaryMods.Exists((CardModificationInfo x) => x.gemify) || card.Info.Gemified;
     }
 
     #endregion
@@ -1796,29 +1716,6 @@ public static class CardExtensions
         return info;
     }
     #endregion
-    
-    /// <summary>
-    /// Gets a PlayableCards using this specific CardInfo.
-    /// Sometimes inscryption clones CardInfo's and sometimes its reused so there may be more than 1 card using the same CardInfo
-    /// </summary>
-    /// <param name="cardInfo">CardInfo to access.</param>
-    /// <returns>Playable Card on the board, in your hand or on display somewhere</returns>
-    public static PlayableCard GetPlayableCard(this CardInfo cardInfo)
-    {
-        if (CostProperties.CostProperties.CardInfoToCard.TryGetValue(cardInfo, out List<WeakReference<PlayableCard>> cardList))
-        {
-            for (int i = cardList.Count - 1; i >= 0; i--)
-            {
-                if (cardList[i].TryGetTarget(out PlayableCard card) && card != null)
-                {
-                    return card;
-                }
-                
-                cardList.RemoveAt(i);
-            }
-        }
-        return null;
-    }
 
     #region PlayableCard
 
@@ -2316,6 +2213,125 @@ public static class CardExtensions
     {
         bool? isOAPI = info.GetExtendedPropertyAsBool("AddedByOldApi");
         return isOAPI.HasValue && isOAPI.Value;
+    }
+    #endregion
+
+    #region Costs
+    /// <summary>
+    /// Gets a PlayableCards using this specific CardInfo.
+    /// Sometimes inscryption clones CardInfo's and sometimes its reused so there may be more than 1 card using the same CardInfo
+    /// </summary>
+    /// <param name="cardInfo">CardInfo to access.</param>
+    /// <returns>Playable Card on the board, in your hand or on display somewhere</returns>
+    public static PlayableCard GetPlayableCard(this CardInfo cardInfo)
+    {
+        if (CostProperties.CostProperties.CardInfoToCard.TryGetValue(cardInfo, out List<WeakReference<PlayableCard>> cardList))
+        {
+            for (int i = cardList.Count - 1; i >= 0; i--)
+            {
+                if (cardList[i].TryGetTarget(out PlayableCard card) && card != null)
+                    return card;
+
+                cardList.RemoveAt(i);
+            }
+        }
+        return null;
+    }
+
+    /// <summary>
+    /// Returns the blood cost of a card.
+    /// This function can be overriden if someone wants to inject new cost into a cards blood cost
+    /// </summary>
+    public static int BloodCost(this PlayableCard card)
+    {
+        //Debug.Log($"{card != null} {card?.Info != null} [{card?.GetType()}] {(card as DiskCardGame.Card)?.Info != null}");
+        if (card && card.Info)
+        {
+            int originalBloodCost = CostProperties.CostProperties.OriginalBloodCost(card.Info);
+
+            if (card.IsUsingBlueGem())
+                originalBloodCost--;
+
+            // add adjustments from temp mods
+            foreach (CardModificationInfo mod in card.TemporaryMods)
+                originalBloodCost += mod.bloodCostAdjustment;
+
+            return originalBloodCost;
+        }
+
+        InscryptionAPIPlugin.Logger.LogError("[BloodCost] Couldn't find Card or CardInfo for blood cost??? How is this possible?");
+        return 0;
+    }
+
+
+    /// <summary>
+    /// Returns the bone cost of a card.
+    /// This function can be overriden if someone wants to inject new cost into a cards bone cost
+    /// </summary>
+    public static int BonesCost(this PlayableCard card)
+    {
+        if (card && card.Info)
+        {
+            int originalBonesCost = CostProperties.CostProperties.OriginalBonesCost(card.Info);
+            if (card.IsUsingBlueGem())
+                originalBonesCost--;
+
+            // add adjustments from temp mods
+            foreach (CardModificationInfo mod in card.TemporaryMods)
+                originalBonesCost += mod.bonesCostAdjustment;
+
+            return originalBonesCost;
+        }
+
+        InscryptionAPIPlugin.Logger.LogError("Couldn't find Card or CardInfo for bone cost??? How is this possible?");
+        return 0;
+    }
+
+
+    /// <summary>
+    /// Returns the gem cost of a card.
+    /// This function can be overriden if someone wants to inject new cost into a cards gem cost
+    /// </summary>
+    public static List<GemType> GemsCost(this PlayableCard card)
+    {
+        if (!card || !card.Info)
+            return new();
+
+        List<CardModificationInfo> mods = card.TemporaryMods.Concat(card.Info.Mods).ToList();
+        // if gems are nullified, return a new list
+        if (mods.Exists((CardModificationInfo x) => x.nullifyGemsCost))
+            return new List<GemType>();
+
+        List<GemType> gemsCost = new(card.Info.gemsCost);
+        foreach (CardModificationInfo mod in mods)
+        {
+            if (mod.addGemCost == null)
+                continue;
+
+            foreach (GemType item in mod.addGemCost)
+            {
+                if (!gemsCost.Contains(item))
+                    gemsCost.Add(item);
+            }
+        }
+
+        if (gemsCost.Count > 0 && card.IsUsingBlueGem())
+            gemsCost.RemoveAt(0);
+
+        return gemsCost;
+    }
+
+    public static bool IsGemified(this PlayableCard card)
+    {
+        return card.Info.Gemified || card.TemporaryMods.Exists((CardModificationInfo x) => x.gemify);
+    }
+    public static bool OwnerHasBlueGem(this PlayableCard card)
+    {
+        return card.OpponentCard ? OpponentGemsManager.Instance.HasGem(GemType.Blue) : ResourcesManager.Instance.HasGem(GemType.Blue);
+    }
+    public static bool IsUsingBlueGem(this PlayableCard card)
+    {
+        return card.IsGemified() && card.OwnerHasBlueGem();
     }
     #endregion
 }

--- a/InscryptionAPI/Card/CostProperties.cs
+++ b/InscryptionAPI/Card/CostProperties.cs
@@ -11,6 +11,63 @@ namespace InscryptionAPI.Card.CostProperties;
 [HarmonyPatch]
 public static class CostProperties
 {
+    public class RefreshCostMonoBehaviour : MonoBehaviour
+    {
+        public PlayableCard playableCard;
+        private int cachedBloodCost = -1, cachedBoneCost = -1;
+        private readonly List<GemType> cachedGemsCost = new();
+
+        private void LateUpdate()
+        {
+            if (DidCostsChangeThisFrame())
+                playableCard.RenderCard();
+        }
+
+        private bool DidCostsChangeThisFrame()
+        {
+            // update all cachedCosts before returning boolean
+            bool refreshCost = false;
+
+            int bloodCost = playableCard?.BloodCost() ?? 0;
+            if (bloodCost != cachedBloodCost)
+            {
+                cachedBloodCost = bloodCost;
+                refreshCost = true;
+            }
+
+            int boneCost = playableCard.BonesCost();
+            if (boneCost != cachedBoneCost)
+            {
+                cachedBoneCost = boneCost;
+                refreshCost = true;
+            }
+
+            List<GemType> gemsCost = playableCard.GemsCost();
+            if (GemsChanged(cachedGemsCost, gemsCost))
+            {
+                cachedGemsCost.Clear();
+                cachedGemsCost.AddRange(gemsCost);
+                refreshCost = true;
+            }
+
+            return refreshCost;
+        }
+
+        public bool GemsChanged<T>(List<T> a, List<T> b)
+        {
+            if (a.Count != b.Count)
+                return true;
+
+            for (int i = 0; i < a.Count; i++)
+            {
+                if (!a[i].Equals(b[i]))
+                    return true;
+            }
+
+            return false;
+        }
+    }
+
     public static ConditionalWeakTable<CardInfo, List<WeakReference<PlayableCard>>> CardInfoToCard = new();
     
     /// <summary>
@@ -39,74 +96,13 @@ public static class CostProperties
     [HarmonyReversePatch, HarmonyPatch(typeof(CardInfo), nameof(CardInfo.GemsCost), MethodType.Getter), MethodImpl(MethodImplOptions.NoInlining)]
     public static List<GemType> OriginalGemsCost(CardInfo __instance) { return null; }
 
-    public class RefreshCostMonoBehaviour : MonoBehaviour
-    {
-        private PlayableCard playableCard;
-        private int cachedBloodCost = -1;
-        private int cachedBoneCost = -1;
-        private readonly List<GemType> cachedGemsCost = new();
-
-        private void Awake()
-        {
-            playableCard = GetComponent<PlayableCard>();
-        }
-    
-        public void LateUpdate()
-        {
-            bool refreshCost = DidCostsChangeThisFrame();
-            if (refreshCost)
-            {
-                playableCard?.RenderCard();
-            }
-        }
-    
-        private bool DidCostsChangeThisFrame()
-        {
-            bool refreshCost = false;
-
-            int bloodCost = playableCard?.BloodCost() ?? 0;
-            if (bloodCost != cachedBloodCost)
-            {
-                cachedBloodCost = bloodCost;
-                refreshCost = true;
-            }
-
-            int boneCost = playableCard?.BonesCost() ?? 0;
-            if (boneCost != cachedBoneCost)
-            {
-                cachedBoneCost = boneCost;
-                refreshCost = true;
-            }
-
-            List<GemType> gemsCost = playableCard?.GemsCost() ?? new();
-            if (!CompareLists(cachedGemsCost, gemsCost))
-            {
-                cachedGemsCost.Clear();
-                cachedGemsCost.AddRange(gemsCost);
-                refreshCost = true;
-            }
-            
-            return refreshCost;
-        }
-
-        public bool CompareLists<T>(List<T> a, List<T> b)
-        {
-            if (a.Count != b.Count)
-            {
-                return false;
-            }
-
-            for (int i = 0; i < a.Count; i++)
-            {
-                if (!a[i].Equals(b[i]))
-                {
-                    return false;
-                }
-            }
-            
-            return true;
-        }
-    }
+    /// <summary>
+    /// ChangeCardCostGetter patches EnergyCost so we can change the cost on the fly
+    /// This reverse patch gives us access to the original method without any changes.
+    /// This method has a copy of all the code that CardInfo.EnergyCost had so it doesn't result in a StackOverflow and freezing the game when called.
+    /// </summary>
+    [HarmonyReversePatch, HarmonyPatch(typeof(CardInfo), nameof(CardInfo.EnergyCost), MethodType.Getter), MethodImpl(MethodImplOptions.NoInlining)]
+    public static int OriginalEnergyCost(CardInfo __instance) { return 0; }
 }
 
 [HarmonyPatch]
@@ -116,13 +112,7 @@ internal static class ChangeCardCostGetter
     public static bool BloodCost(CardInfo __instance, ref int __result)
     {
         PlayableCard card = __instance.GetPlayableCard();
-        if (card == null)
-        {
-            __result = CostProperties.OriginalBloodCost(__instance);
-            return false;
-        }
-        
-        __result = Mathf.Max(0, card.BloodCost());
+        __result = Mathf.Max(0, card?.BloodCost() ?? CostProperties.OriginalBloodCost(__instance));
         return false;
     }
     
@@ -131,17 +121,9 @@ internal static class ChangeCardCostGetter
     {
         PlayableCard card = __instance.GetPlayableCard();
         if (card == null)
-        {
             return true;
-        }
-        
-        int num = card.BonesCost();
-        if (IsUsingBlueGem(card))
-        {
-            num--;
-        }
-        
-        __result = Mathf.Max(0, num);
+
+        __result = Mathf.Max(0, card.BonesCost());
         return false;
     }
     
@@ -149,62 +131,41 @@ internal static class ChangeCardCostGetter
     public static bool GemsCost(CardInfo __instance, ref List<GemType> __result)
     {
         PlayableCard card = __instance.GetPlayableCard();
-        if (card == null)
-        {
-            __result = CostProperties.OriginalGemsCost(__instance);
-            return false;
-        }
-        
-        __result = card.GemsCost();
+        __result = card?.GemsCost() ?? CostProperties.OriginalGemsCost(__instance);
         return false;
     }
     
-    [HarmonyPatch(typeof(PlayableCard), nameof(PlayableCard.EnergyCost), MethodType.Getter), HarmonyPostfix]
-    public static void EnergyCost(PlayableCard __instance, ref int __result)
+    [HarmonyPatch(typeof(CardInfo), nameof(CardInfo.EnergyCost), MethodType.Getter), HarmonyPrefix]
+    public static bool EnergyCost(CardInfo __instance, ref int __result)
     {
-        if (!Singleton<ResourcesManager>.Instance.HasGem(GemType.Blue))
-        {
-            return;
-        }
-
-        if (__instance.Info.Gemified)
-        {
-            // --1 already applied by CardInfo logic
-            return;
-        }
-
-        if (__instance.TemporaryMods.Exists((CardModificationInfo x) => x.gemify))
-        {
-            // --1 because we added it as a temporary mod
-            __result = Mathf.Max(0, __result - 1);
-        };
+        PlayableCard card = __instance.GetPlayableCard();
+        __result = card?.EnergyCost ?? CostProperties.OriginalEnergyCost(__instance);
+        return false;
     }
-
-    public static bool IsUsingBlueGem(PlayableCard card)
+    [HarmonyPatch(typeof(PlayableCard), nameof(PlayableCard.EnergyCost), MethodType.Getter), HarmonyPrefix]
+    public static bool DisableVanillaEnergyCost(PlayableCard __instance, ref int __result)
     {
-        if (!Singleton<ResourcesManager>.Instance.HasGem(GemType.Blue))
-        {
-            return false;
-        }
+        // patch this to follow the same pattern as the other cost methods
+        int energyCost = CostProperties.OriginalEnergyCost(__instance.Info);
+        if (__instance.IsUsingBlueGem())
+            energyCost--;
 
-        if (card.Info.Gemified)
-        {
-            return true;
-        }
-        
-        return card.TemporaryMods.Exists((CardModificationInfo x) => x.gemify);
+        foreach (CardModificationInfo mod in __instance.TemporaryMods)
+            energyCost += mod.energyCostAdjustment;
+
+        __result = Mathf.Max(0, energyCost);
+        return false;
     }
 }
 
-[HarmonyPatch(typeof(DiskCardGame.Card), nameof(DiskCardGame.Card.Info), MethodType.Setter)]
+/*[HarmonyPatch(typeof(DiskCardGame.Card), nameof(DiskCardGame.Card.Info), MethodType.Setter)]
 internal static class Card_SetInfo
 {
     public static void Postfix(DiskCardGame.Card __instance)
     {
+        //return;
         if (__instance is not PlayableCard playableCard)
-        {
             return;
-        }
         
         CardInfo info = playableCard.Info;
         
@@ -235,34 +196,71 @@ internal static class Card_SetInfo
         }
         else
         {
+            Debug.Log($"New-un");
             CostProperties.CardInfoToCard.Add(info, new List<WeakReference<PlayableCard>>()
             {
                 new WeakReference<PlayableCard>(playableCard)
             });
         }
     }
-}
+}*/
 
-[HarmonyPatch(typeof(PlayableCard), nameof(PlayableCard.Awake))]
-internal static class PlayableCard_Awake
+[HarmonyPatch(typeof(PlayableCard), nameof(PlayableCard.SetInfo))]
+internal static class AddRefreshBehaviourToCard
 {
-    public static void Postfix(PlayableCard __instance)
+    private static void Postfix(PlayableCard __instance)
     {
+        // add the refresh component if it doesn't exist, then set the Card to the calling instance
         if (__instance.GetComponent<CostProperties.RefreshCostMonoBehaviour>() == null)
-            __instance.gameObject.AddComponent<CostProperties.RefreshCostMonoBehaviour>();
+        {
+            __instance.gameObject.AddComponent<CostProperties.RefreshCostMonoBehaviour>().playableCard = __instance;
+            if (CostProperties.CardInfoToCard.TryGetValue(__instance.Info, out List<WeakReference<PlayableCard>> cardList))
+            {
+                PlayableCard card = null;
+                for (int i = cardList.Count - 1; i >= 0; i--)
+                {
+                    if (!cardList[i].TryGetTarget(out PlayableCard innerCard) || innerCard == null)
+                    {
+                        // NOTE: We store a list of cards so if we don't clear this list then it will fill up forever
+                        cardList.RemoveAt(i);
+                    }
+                    else if (innerCard == __instance)
+                    {
+                        card = innerCard;
+                    }
+                }
+
+                if (card == null)
+                {
+                    cardList.Add(new WeakReference<PlayableCard>(__instance));
+                    if (cardList.Count > 1)
+                    {
+                        InscryptionAPIPlugin.Logger.LogWarning($"More than 1 card are using the same card info. This can cause unexpected problems with dynamic costs! {__instance.Info.displayedName}");
+                    }
+                }
+            }
+            else
+            {
+                CostProperties.CardInfoToCard.Add(__instance.Info, new List<WeakReference<PlayableCard>>()
+                {
+                    new WeakReference<PlayableCard>(__instance)
+                });
+            }
+
+        }
     }
 }
 
 [HarmonyPatch]
 internal static class TurnManager_CleanupPhase
 {
-    public static IEnumerable<MethodBase> TargetMethods()
+    private static IEnumerable<MethodBase> TargetMethods()
     {
         yield return AccessTools.Method(typeof(TurnManager), nameof(TurnManager.CleanupPhase));
         yield return AccessTools.Method(typeof(GBCEncounterManager), nameof(GBCEncounterManager.LoadOverworldScene));
     }
     
-    public static void Postfix()
+    private static void Postfix()
     {
         // NOTE: This is a hack to clear the table
         CostProperties.CardInfoToCard = new ConditionalWeakTable<CardInfo, List<WeakReference<PlayableCard>>>(); 

--- a/InscryptionAPI/Card/OpponentGemsManager.cs
+++ b/InscryptionAPI/Card/OpponentGemsManager.cs
@@ -5,6 +5,7 @@ public class OpponentGemsManager : Singleton<OpponentGemsManager>
 {
     public List<GemType> opponentGems = new();
 
+    public int GemsOfType(GemType gem) => opponentGems.Count(x => x == gem);
     public bool HasGem(GemType gem) => opponentGems.Contains(gem);
     public void AddGem(GemType gem) => opponentGems.Add(gem);
     public void LoseGem(GemType gem) => opponentGems.Remove(gem);

--- a/InscryptionAPI/Helpers/ResourcesManagerHelpers.cs
+++ b/InscryptionAPI/Helpers/ResourcesManagerHelpers.cs
@@ -5,6 +5,17 @@ namespace InscryptionAPI.Helpers;
 
 public static class ResourcesManagerHelpers
 {
+    public static int GemsOfType(this ResourcesManager instance, GemType gem)
+    {
+        return instance.gems.Count(x => x == gem);
+    }
+    public static int GemCount(bool playerGems, GemType gemToCheck)
+    {
+        if (playerGems)
+            return ResourcesManager.Instance.GemsOfType(gemToCheck);
+        else
+            return OpponentGemsManager.Instance.GemsOfType(gemToCheck);
+    }
     public static bool OwnerHasGems(bool playerGems, params GemType[] gems)
     {
         if (playerGems)
@@ -14,13 +25,12 @@ public static class ResourcesManagerHelpers
     }
     public static bool OpponentHasGems(params GemType[] gems)
     {
-        var component = ResourcesManager.Instance.GetComponent<OpponentGemsManager>();
-        if (component == null)
+        if (OpponentGemsManager.Instance == null)
             return false;
 
         foreach (GemType gem in gems)
         {
-            if (!component.opponentGems.Contains(gem))
+            if (!OpponentGemsManager.Instance.HasGem(gem))
                 return false;
         }
         return true;
@@ -29,7 +39,7 @@ public static class ResourcesManagerHelpers
     {
         foreach (GemType gem in gems)
         {
-            if (!ResourcesManager.Instance.gems.Contains(gem))
+            if (!ResourcesManager.Instance.HasGem(gem))
                 return false;
         }
         return true;

--- a/InscryptionAPI/InscryptionAPI.csproj
+++ b/InscryptionAPI/InscryptionAPI.csproj
@@ -10,7 +10,7 @@
         <DebugType>full</DebugType>
         <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
         <EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>
-        <Version>2.14.0</Version>
+        <Version>2.14.3</Version>
     </PropertyGroup>
 
     <ItemGroup>

--- a/InscryptionAPI/InscryptionAPIPlugin.cs
+++ b/InscryptionAPI/InscryptionAPIPlugin.cs
@@ -26,7 +26,7 @@ public class InscryptionAPIPlugin : BaseUnityPlugin
 {
     public const string ModGUID = "cyantist.inscryption.api";
     public const string ModName = "InscryptionAPI";
-    public const string ModVer = "2.14.2";
+    public const string ModVer = "2.14.3";
 
     internal static ConfigEntry<bool> configOverrideArrows;
     internal static ConfigEntry<TotemManager.TotemTopState> configCustomTotemTopTypes;

--- a/InscryptionAPI/PixelCard/PixelCardManager.cs
+++ b/InscryptionAPI/PixelCard/PixelCardManager.cs
@@ -46,7 +46,7 @@ public static class PixelCardManager // code courtesy of Nevernamed and James/ke
     }
 
     [HarmonyPostfix, HarmonyPatch(typeof(CardAppearanceBehaviour), nameof(CardAppearanceBehaviour.Card), MethodType.Getter)]
-    private static void GetCorrectCard(CardAppearanceBehaviour __instance, ref DiskCardGame.Card __result)
+    private static void GetCorrectCardComponentInAct2(CardAppearanceBehaviour __instance, ref DiskCardGame.Card __result)
     {
         if (SaveManager.SaveFile.IsPart2)
             __result = __instance.GetComponentInParent<DiskCardGame.Card>();
@@ -134,16 +134,16 @@ public static class PixelCardManager // code courtesy of Nevernamed and James/ke
             Component behav = instance.gameObject.GetComponent(fullApp.AppearanceBehaviour);
             behav ??= instance.gameObject.AddComponent(fullApp.AppearanceBehaviour);
 
-            if (behav is PixelAppearanceBehaviour)
+            if (behav is PixelAppearanceBehaviour pixelBehav)
             {
-                (behav as PixelAppearanceBehaviour).OnAppearanceApplied();
-                Sprite behavAppearance = (behav as PixelAppearanceBehaviour).PixelAppearance();
+                pixelBehav.OnAppearanceApplied();
+                Sprite behavAppearance = pixelBehav.PixelAppearance();
                 Transform behavTransform = cardElements.Find(appearance.ToString() + "_Displayer");
 
                 if (behavAppearance != null && behavTransform == null)
                     CreateDecal(in cardElements, behavAppearance, appearance.ToString() + "_Displayer");
                 // override portrait
-                Sprite overridePortrait = (behav as PixelAppearanceBehaviour).OverridePixelPortrait();
+                Sprite overridePortrait = pixelBehav.OverridePixelPortrait();
                 if (overridePortrait != null)
                     instance.SetPortrait(overridePortrait);
             }

--- a/InscryptionCommunityPatch/Card/Part1CardCostRender.cs
+++ b/InscryptionCommunityPatch/Card/Part1CardCostRender.cs
@@ -15,7 +15,7 @@ public static class Part1CardCostRender
 
     public static event Action<CardInfo, List<Texture2D>> UpdateCardCost;
 
-    private static Dictionary<string, Texture2D> AssembledTextures = new();
+    private static readonly Dictionary<string, Texture2D> AssembledTextures = new();
 
     public const int COST_OFFSET = 28;
 
@@ -53,13 +53,12 @@ public static class Part1CardCostRender
     public static Sprite Part1SpriteFinal(CardInfo cardInfo)
     {
         PlayableCard playableCard = cardInfo.GetPlayableCard();
-        bool hasPlayableCard = playableCard != null; // Micro-optimisation since this method is caleld frequently
-        
+
         // A list to hold the textures (important later, to combine them all)
         List<Texture2D> list = new();
 
         // Setting mox first
-        List<GemType> gemsCost = hasPlayableCard ? playableCard.GemsCost() : cardInfo.GemsCost;
+        List<GemType> gemsCost = playableCard?.GemsCost() ?? cardInfo.GemsCost;
         if (gemsCost.Count > 0)
         {
             // Make a new list for the mox textures
@@ -82,15 +81,15 @@ public static class Part1CardCostRender
             list.Add(CombineMoxTextures(gemCost));
         }
 
-        int energyCost = hasPlayableCard ? playableCard.EnergyCost : cardInfo.EnergyCost;
+        int energyCost = playableCard?.EnergyCost ?? cardInfo.EnergyCost;
         if (energyCost > 0) // there's 6+ texture but since Energy can't go above 6 normally I have excluded it from consideration
             list.Add(GetTextureByName($"energy_cost_{Mathf.Min(6, energyCost)}"));
 
-        int bonesCost = hasPlayableCard ? playableCard.BonesCost() : cardInfo.BonesCost;
+        int bonesCost = playableCard?.BonesCost() ?? cardInfo.BonesCost;
         if (bonesCost > 0)
             list.Add(GetTextureByName($"bone_cost_{Mathf.Min(14, bonesCost)}"));
 
-        int bloodCost = hasPlayableCard ? playableCard.BloodCost() : cardInfo.BloodCost;
+        int bloodCost = playableCard?.BloodCost() ?? cardInfo.BloodCost;
         if (bloodCost > 0)
             list.Add(GetTextureByName($"blood_cost_{Mathf.Min(14, bloodCost)}"));
 
@@ -106,16 +105,16 @@ public static class Part1CardCostRender
 
     [HarmonyPatch(typeof(CardDisplayer), nameof(CardDisplayer.GetCostSpriteForCard))]
     [HarmonyPrefix]
-    private static bool Part1CardCostDisplayerPatch(ref Sprite __result, ref CardInfo card, ref CardDisplayer __instance)
+    private static bool Part1CardCostDisplayerPatch(ref Sprite __result, CardDisplayer __instance, CardInfo card)
     {
         //Make sure we are in Leshy's Cabin
         if (__instance is CardDisplayer3D && SceneLoader.ActiveSceneName.StartsWith("Part1"))
         {
-            /// Set the results as the new sprite
+            // Set the results as the new sprite
             __result = Part1SpriteFinal(card);
             return false;
         }
-
+        
         return true;
     }
 }

--- a/InscryptionCommunityPatch/Card/Part2CardCostRender.cs
+++ b/InscryptionCommunityPatch/Card/Part2CardCostRender.cs
@@ -16,14 +16,12 @@ public static class Part2CardCostRender
 
     public static event Action<CardInfo, List<Texture2D>> UpdateCardCost;
 
-    //private static Dictionary<string, Texture2D> AssembledTextures = new();
-
     public static Texture2D CombineIconAndCount(int cardCost, Texture2D artCost)
     {
         bool left = !PatchPlugin.rightAct2Cost.Value;
         Texture2D baseTexture = TextureHelper.GetImageAsTexture("pixel_blank.png", typeof(Part2CardCostRender).Assembly);
 
-        List<Texture2D> list = new List<Texture2D>();
+        List<Texture2D> list = new();
         if (cardCost <= 4)
         {
             for (int i = 0; i < cardCost; i++)
@@ -44,7 +42,7 @@ public static class Part2CardCostRender
         bool left = !PatchPlugin.rightAct2Cost.Value;
 
         // A list to hold the textures (important later, to combine them all)
-        List<Texture2D> masterList = new List<Texture2D>();
+        List<Texture2D> masterList = new();
 
         if (card.BloodCost > 0)
             masterList.Add(CombineIconAndCount(card.BloodCost, TextureHelper.GetImageAsTexture("pixel_blood.png", typeof(Part2CardCostRender).Assembly)));
@@ -55,9 +53,9 @@ public static class Part2CardCostRender
         if (card.EnergyCost > 0)
             masterList.Add(CombineIconAndCount(card.EnergyCost, TextureHelper.GetImageAsTexture("pixel_energy.png", typeof(Part2CardCostRender).Assembly)));
 
-        if (card.gemsCost.Count > 0)
+        if (card.GemsCost.Count > 0)
         {
-            List<Texture2D> gemCost = new List<Texture2D>();
+            List<Texture2D> gemCost = new();
 
             //If a card has a green mox, set the green mox
             if (card.GemsCost.Contains(GemType.Green))
@@ -96,10 +94,10 @@ public static class Part2CardCostRender
     [HarmonyPrefix]
     private static bool Part2CardCostDisplayerPatch(ref Sprite __result, ref CardInfo card, ref CardDisplayer __instance)
     {
-        //Make sure we are only modifying pixel cards
+        // Make sure we are only modifying pixel cards
         if (__instance is PixelCardDisplayer && PatchPlugin.act2CostRender.Value)
         {
-            /// Set the results as the new sprite
+            // Set the results as the new sprite
             __result = Part2SpriteFinal(card);
             return false;
         }

--- a/InscryptionCommunityPatch/Card/Vanilla Ability Patches/EvolveDescriptionFixes.cs
+++ b/InscryptionCommunityPatch/Card/Vanilla Ability Patches/EvolveDescriptionFixes.cs
@@ -88,7 +88,8 @@ internal static class EvolveDescriptionFixes
     private static void DisplayDescription(CardPreviewPanel instance, CardInfo cardInfo, List<Ability> abilities, PlayableCard card)
     {
         // don't display hidden abilities' descriptions
-        abilities.RemoveAll(x => card.Status.hiddenAbilities.Contains(x));
+        if (card != null)
+            abilities.RemoveAll(x => card.Status.hiddenAbilities.Contains(x));
 
         instance.DisplayDescription(cardInfo, abilities);
         string gbcDescriptionLocalized = GetUpdatedDescription(instance.descriptionText.hiddenText.Text, card, cardInfo, abilities);

--- a/InscryptionCommunityPatch/Card/Vanilla Ability Patches/EvolveDescriptionFixes.cs
+++ b/InscryptionCommunityPatch/Card/Vanilla Ability Patches/EvolveDescriptionFixes.cs
@@ -84,8 +84,12 @@ internal static class EvolveDescriptionFixes
         return codes;
     }
 
+    // expanded forme of DisplayDescription that includes the card instance
     private static void DisplayDescription(CardPreviewPanel instance, CardInfo cardInfo, List<Ability> abilities, PlayableCard card)
     {
+        // don't display hidden abilities' descriptions
+        abilities.RemoveAll(x => card.Status.hiddenAbilities.Contains(x));
+
         instance.DisplayDescription(cardInfo, abilities);
         string gbcDescriptionLocalized = GetUpdatedDescription(instance.descriptionText.hiddenText.Text, card, cardInfo, abilities);
 

--- a/InscryptionCommunityPatch/ResourceManagers/ActOneEnergyDrone.cs
+++ b/InscryptionCommunityPatch/ResourceManagers/ActOneEnergyDrone.cs
@@ -214,8 +214,12 @@ public static class EnergyDrone
     {
         if (__instance is Part1ResourcesManager && EnergyConfig.ConfigDrone)
         {
-            ResourceDrone.Instance.OpenCell(__instance.PlayerMaxEnergy - 1);
-            yield return new WaitForSeconds(0.4f);
+            int cellsToOpen = __instance.PlayerMaxEnergy - 1;
+            if (cellsToOpen > 0)
+            {
+                ResourceDrone.Instance.OpenCell(cellsToOpen);
+                yield return new WaitForSeconds(0.4f);
+            }
         }
 
         yield return result;


### PR DESCRIPTION
- Fixed dynamic costs still not working in Act 2
- Fixed dynamic gem costs checking ResourcesManager instead of OpponentGemsManager for opponent cards
- Fixed dynamic costs not checking for owned blue gems
- Fixed dynamic costs not updating energy display correctly
- Changed dynamic costs to patch SetInfo instead of Awake
- Re-added dynamic cost error messages for when the card or card info is null
- Added ResourcesManager.Instance.GemsOfType(GemType) to check for owned gems of the specified type