### PR TITLE
2.14.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+<details>
+<summary>View Changelog</summary>
+
+## 2.14.4
+- Fixed the first energy cell remaining closed in Act 1 when battle starts
+- Added new field to PeltManager.PeltData 'peltTierName' used when trading pelts
+- Added extension method PeltData.SetTierName
+- The Trader will now speak the correct name of custom pelts when trading with them
+- Added DialogueManager.GenerateTraderPeltsEvent for creating custom dialogue events spoken by the Trader when trading a custom pelt
+- Added DialogueManager.GenerateRegionIntroEvent for creating the dialogue event played upon entering a custom region
+
 ## 2.14.3
 - Fixed Act 2 bug relating to stackable sigils and activated sigils in the deck display menu
 - Fixed dynamic costs still not working in Act 2
@@ -392,3 +403,5 @@
 
 ## v1.1
 - Hooked into a much more sensible method to load the cards into the card pool.
+
+</details>

--- a/InscryptionAPI/Dialogue/DialogueManager.cs
+++ b/InscryptionAPI/Dialogue/DialogueManager.cs
@@ -1,6 +1,7 @@
 using DiskCardGame;
 using GBC;
 using HarmonyLib;
+using InscryptionAPI.Pelts;
 using System.Collections;
 using UnityEngine;
 using static DiskCardGame.TextDisplayer;
@@ -65,6 +66,24 @@ public static class DialogueManager
 
         Add(pluginGUID, ev);
         return ev;
+    }
+
+    public static DialogueEvent GenerateTraderPeltsEvent(string pluginGUID, PeltManager.PeltData peltData, List<CustomLine> lines, List<List<CustomLine>> repeatLines = null)
+    {
+        return GenerateTraderPeltsEvent(pluginGUID, peltData.peltTierName ?? PeltManager.GetTierNameFromData(peltData), lines, repeatLines);
+    }
+    public static DialogueEvent GenerateTraderPeltsEvent(string pluginGUID, string peltTierName, List<CustomLine> lines, List<List<CustomLine>> repeatLines = null)
+    {
+        return GenerateEvent(pluginGUID, "TraderPelts" + peltTierName, lines, repeatLines);
+    }
+
+    public static DialogueEvent GenerateRegionIntroductionEvent(string pluginGUID, RegionData regionData, List<CustomLine> lines, List<List<CustomLine>> repeatLines = null)
+    {
+        return GenerateRegionIntroductionEvent(pluginGUID, regionData.name, lines, repeatLines);
+    }
+    public static DialogueEvent GenerateRegionIntroductionEvent(string pluginGUID, string regionName, List<CustomLine> lines, List<List<CustomLine>> repeatLines = null)
+    {
+        return GenerateEvent(pluginGUID, "Region" + regionName, lines, repeatLines);
     }
 
     public static IEnumerator PlayDialogueEventSafe(string eventId,

--- a/InscryptionAPI/InscryptionAPIPlugin.cs
+++ b/InscryptionAPI/InscryptionAPIPlugin.cs
@@ -9,6 +9,7 @@ using InscryptionAPI.Card;
 using InscryptionAPI.Dialogue;
 using InscryptionAPI.Encounters;
 using InscryptionAPI.Items;
+using InscryptionAPI.Pelts;
 using InscryptionAPI.PixelCard;
 using InscryptionAPI.Regions;
 using InscryptionAPI.Totems;
@@ -26,7 +27,7 @@ public class InscryptionAPIPlugin : BaseUnityPlugin
 {
     public const string ModGUID = "cyantist.inscryption.api";
     public const string ModName = "InscryptionAPI";
-    public const string ModVer = "2.14.3";
+    public const string ModVer = "2.14.4";
 
     internal static ConfigEntry<bool> configOverrideArrows;
     internal static ConfigEntry<TotemManager.TotemTopState> configCustomTotemTopTypes;
@@ -110,6 +111,7 @@ public class InscryptionAPIPlugin : BaseUnityPlugin
         ResyncAll();
         CardManager.AuditCardList();
         PixelCardManager.Initialise();
+        PeltManager.CreateDialogueEvents();
         Logger.LogInfo($"Inserted {DialogueManager.CustomDialogue.Count} dialogue event(s)!");
     }
 

--- a/InscryptionAPI/Pelts/Patches/BuyPeltsSequencer_Patches.cs
+++ b/InscryptionAPI/Pelts/Patches/BuyPeltsSequencer_Patches.cs
@@ -32,12 +32,7 @@ internal class BuyPeltsSequencer_BuyPelts
     {
         get
         {
-            if (m_specialNodeHandler == null)
-            {
-                m_specialNodeHandler = SpecialNodeHandler.Instance.buyPeltsSequencer;
-            }
-
-            return m_specialNodeHandler;
+            return m_specialNodeHandler ??= SpecialNodeHandler.Instance.buyPeltsSequencer;
         }
     }
     private static BuyPeltsSequencer m_specialNodeHandler;
@@ -96,8 +91,10 @@ internal class BuyPeltsSequencer_BuyPelts
             // Ensure we have a PeltHare
             // We have at least 1 rare
             // Sort by cost
-            List<PeltManager.PeltData> selectedCards = new List<PeltManager.PeltData>(8);
-            selectedCards.Add(PeltManager.GetPelt("PeltHare"));
+            List<PeltManager.PeltData> selectedCards = new(8)
+            {
+                PeltManager.GetPelt("PeltHare")
+            };
 
             List<PeltManager.PeltData> allCards = new(availableAtTrader);
             allCards.Remove(selectedCards[0]);
@@ -229,7 +226,7 @@ internal class BuyPeltsSequencer_CreatePelt
         MethodInfo PeltNamesInfo = AccessTools.PropertyGetter(typeof(CardLoader), "PeltNames");
         MethodInfo AllPeltsAvailableAtTraderInfo = SymbolExtensions.GetMethodInfo(() => GetCardByName());
 
-        List<CodeInstruction> codes = new List<CodeInstruction>(instructions);
+        List<CodeInstruction> codes = new(instructions);
         for (int i = 0; i < codes.Count; i++)
         {
             CodeInstruction code = codes[i];

--- a/InscryptionAPI/Pelts/Patches/TradePeltsSequencer_Patches.cs
+++ b/InscryptionAPI/Pelts/Patches/TradePeltsSequencer_Patches.cs
@@ -7,13 +7,26 @@ using UnityEngine;
 
 namespace InscryptionAPI.Pelts.Patches;
 
+[HarmonyPatch]
+internal class TradePeltsDialogue
+{
+    [HarmonyPostfix, HarmonyPatch(typeof(TradePeltsSequencer), nameof(TradePeltsSequencer.GetTierName))]
+    private static void AddCustomTierNames(int tier, ref string __result)
+    {
+        if (tier < 3)
+            return;
+
+        __result = PeltManager.GetTierNameFromData(PeltManager.AllPelts()[tier]);
+    }
+}
+
 [HarmonyPatch(typeof(TradePeltsSequencer), "GetTradeCardInfos", new Type[] { typeof(int), typeof(bool) })]
 internal static class TradePeltsSequencer_GetTradeCardInfos
 {
     /// <summary>
     /// Shows cards at the Trader to be traded for real cards
     /// </summary>
-    public static IEnumerable<CodeInstruction> Transpiler(IEnumerable<CodeInstruction> instructions)
+    private static IEnumerable<CodeInstruction> Transpiler(IEnumerable<CodeInstruction> instructions)
     {
         // === We want to turn this
 
@@ -52,7 +65,7 @@ internal static class TradePeltsSequencer_GetTradeCardInfos
         // list = CardLoader.GetDistinctCardsFromPool(SaveManager.SaveFile.GetCurrentRandomSeed() + tier * 1000, numCards, unlockedCards, abilityCount((tier == 1) ? 1 : 0, tier), false);
 
         // ===
-        List<CodeInstruction> codes = new List<CodeInstruction>(instructions);
+        List<CodeInstruction> codes = new(instructions);
 
         List<CardInfo> y = null;
         MethodInfo GetCardOptionsInfo = SymbolExtensions.GetMethodInfo(() => GetCardOptions(1, ref y));

--- a/InscryptionAPI/Pelts/PeltExtensions.cs
+++ b/InscryptionAPI/Pelts/PeltExtensions.cs
@@ -115,4 +115,17 @@ public static class PeltExtensions
         peltData.CardChoices = getCardChoices;
         return peltData;
     }
+
+    /// <summary>
+    /// Sets the name used by the Trader when trading this pelt to them.
+    /// Also used to determine the eventId of the corresponding DialogueEvent.
+    /// </summary>
+    /// <param name="peltData">The PeltData to access.</param>
+    /// <param name="tierName">The name that will be spoken by the Trader and used to reference the custom dialogue event.</param>
+    /// <returns>The same PeltData so a chain can continue.</returns>
+    public static PeltData SetTierName(this PeltData peltData, string tierName)
+    {
+        peltData.peltTierName = tierName;
+        return peltData;
+    }
 }

--- a/InscryptionAPI/Totems/TotemManager.cs
+++ b/InscryptionAPI/Totems/TotemManager.cs
@@ -313,7 +313,7 @@ public static class TotemManager
             addComponent.Rebind();
         }
 
-        // Mark as dont destroy on load so it doesn't get removed between levels
+        // Mark as don't destroy on load so it doesn't get removed between levels
         UnityObject.DontDestroyOnLoad(prefab);
     }
 

--- a/InscryptionCommunityPatch/ResourceManagers/ActOneEnergyDrone.cs
+++ b/InscryptionCommunityPatch/ResourceManagers/ActOneEnergyDrone.cs
@@ -197,14 +197,14 @@ public static class EnergyDrone
     [HarmonyPrefix]
     private static void ResourcesManager_Setup(ResourcesManager __instance)
     {
-        if (EnergyConfig.ConfigDrone)
-            PatchPlugin.Logger.LogDebug("Setting up extra resources for the drone.");
-
         if (__instance is Part1ResourcesManager && EnergyConfig.ConfigDrone)
         {
             ResourceDrone.Instance.SetOnBoard(true, false);
             if (EnergyConfig.ConfigDroneMox)
+            {
+                PatchPlugin.Logger.LogDebug("Setting up extra resources for the drone.");
                 ResourceDrone.Instance.Gems.SetAllGemsOn(false, true);
+            }
         }
     }
 
@@ -215,11 +215,8 @@ public static class EnergyDrone
         if (__instance is Part1ResourcesManager && EnergyConfig.ConfigDrone)
         {
             int cellsToOpen = __instance.PlayerMaxEnergy - 1;
-            if (cellsToOpen > 0)
-            {
-                ResourceDrone.Instance.OpenCell(cellsToOpen);
-                yield return new WaitForSeconds(0.4f);
-            }
+            ResourceDrone.Instance.OpenCell(cellsToOpen);
+            yield return new WaitForSeconds(0.4f);
         }
 
         yield return result;

--- a/README.md
+++ b/README.md
@@ -30,9 +30,12 @@ This is the recommended way to install the API on the game.
 - Run the game via the mod manager
 
 ## Installation (manual)
-To install this plugin first you need to install BepInEx as a mod loader for Inscryption. A guide to do this can be found [here](https://docs.bepinex.dev/articles/user_guide/installation/index.html#where-to-download-bepinex). Inscryption needs the 86x (32 bit) mono version.
+To install this plugin first you need to install BepInEx as a mod loader for Inscryption. A guide to do this can be found [here](https://docs.bepinex.dev/articles/user_guide/installation/index.html#where-to-download-bepinex). Inscryption needs the 86x (32 bit) mono version.  
+You also need to install [MonoMod Loader Inscryption](https://inscryption.thunderstore.io/package/BepInEx/MonoMod_Loader_Inscryption/).
 
-To install Inscryption API you simply need to copy **InscryptionAPI.dll** from [releases](https://github.com/ScottWilson0903/InscryptionAPI/releases) to **Inscryption/BepInEx/plugins**.
+- Copy the 'plugins' folder into 'BepInEx/plugins'.
+- Copy the 'monomod' folder into 'BepInEx/monomod'.  
+(If any of these folders do not exist, just create them.)
 
 An example Mod utilising this plugin can be found [here](https://github.com/ScottWilson0903/InscryptionExampleMod).
 


### PR DESCRIPTION
- Fixed the first energy cell remaining closed in Act 1 when battle starts
- Added new field to PeltManager.PeltData 'peltTierName' used when trading pelts
- Added extension method PeltData.SetTierName
- The Trader will now speak the correct name of custom pelts when trading with them
- Added DialogueManager.GenerateTraderPeltsEvent for creating custom dialogue events spoken by the Trader when trading a custom pelt
- Added DialogueManager.GenerateRegionIntroEvent for creating the dialogue event played upon entering a custom region