### PR TITLE
Small Part 3 Bones Manager Fix

### DIFF
--- a/InscryptionCommunityPatch/ResourceManagers/ActThreeBonesDisplayer.cs
+++ b/InscryptionCommunityPatch/ResourceManagers/ActThreeBonesDisplayer.cs
@@ -47,13 +47,25 @@ public static class Act3BonesDisplayer
 
     private static GameObject BonesTVScreen
     {
-        get { return _boneTvScreen.GetOrCreateValue(ResourceDrone.Instance); }
+        get 
+        { 
+            GameObject tvScreen;
+            if (_boneTvScreen.TryGetValue(ResourceDrone.Instance, out tvScreen))
+                return tvScreen;
+            return null;
+        }
         set { _boneTvScreen.Add(ResourceDrone.Instance, value); }
     }
 
     private static SpriteRenderer BonesCountRenderer
     {
-        get { return _boneCountRenderer.GetOrCreateValue(ResourceDrone.Instance); }
+        get 
+        { 
+            SpriteRenderer tvScreen;
+            if (_boneCountRenderer.TryGetValue(ResourceDrone.Instance, out tvScreen))
+                return tvScreen;
+            return null;
+        }
         set { _boneCountRenderer.Add(ResourceDrone.Instance, value); }
     }
 

--- a/InscryptionCommunityPatch/ResourceManagers/ActThreeBonesDisplayer.cs
+++ b/InscryptionCommunityPatch/ResourceManagers/ActThreeBonesDisplayer.cs
@@ -28,7 +28,7 @@ public static class Act3BonesDisplayer
         x == CardMetaCategory.ChoiceNode || x == CardMetaCategory.Part3Random || x == CardMetaCategory.Rare);
     }
 
-    public static bool PoolHasBones => CardManager.AllCardsCopy.Any(ci => ci.energyCost > 0 && ci.CardIsVisible());
+    public static bool PoolHasBones => CardManager.AllCardsCopy.Any(ci => ci.BonesCost > 0 && ci.CardIsVisible());
 
     public static bool SceneCanHaveBonesDisplayer
     {


### PR DESCRIPTION
This fixes a bug in the Part 3 Bones Manager.

The ``PoolHasBones`` helper method erroneously checked `EnergyCost` instead of `BonesCost` when checking to see if the active card pool had any cards with a bones cost. This was causing the bones display TV to always appear, even when the player has no bones cards active in Part 3.