### PR TITLE
Alt portraits for SteelTrap and lost shield, more triggers for TakeDamage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,8 @@
 - Added ability interfaces IModifyDamageTaken, IPreTakeDamage; both trigger at the start of the TakeDamage method
 - Added support for adding alternate portraits specific to the Steel Trap ability effect and broken shield effect
 - Added CardInfo extension methods SetSteelTrapPortrait(), SetBrokenShieldPortrait()
-- Added public methods TakeDamagePatches.BreakShield() and TakeDamage.NewHasShield() - both used in the new shield logic
+- Added PlayableCard extension method ResetShield(Ability) for resetting shields belonging to a certain ability
+- Added ShieldManager for managing new shield logic, patches, and methods
 - Added abstract classes DamageShieldBehaviour and ActivatedDamageShieldBehaviour
 - Changed how shields are detected and tracked to allow for multiple shields on a card
 - DeathShield ability now has a custom AbilityBehaviour attached to it, no longer marked as passive

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,8 @@
 - Added abstract classes DamageShieldBehaviour and ActivatedDamageShieldBehaviour
 - Added support for adding alternate portraits for SteelTrap activation and broken shields
 - Added portrait setters SetSteelTrapPortrait(), SetBrokenShieldPortrait(), SetPixelSteelTrapPortrait(), SetPixelBrokenShieldPortrait()
-- Added AbilityInfo extension method SetHideSingleStacks(), affecting how stacking sigils are affected by being hidden
+- Added support for adding new language translations
+- Added AbilityInfo extension method SetHideSingleStacks(), affecting how stacking sigils are affected by being hidden (see wiki)
 - DeathShield ability now has a custom AbilityBehaviour attached to it
 - DeathShield ability is no longer passive, and can stack
 - TakeDamage trigger now requires damage to be above 0 to activate

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,8 +8,16 @@
 - Added ability interfaces IModifyDamageTaken, IPreTakeDamage
 - Added support for adding alternate portraits specific to the Steel Trap ability effect and broken shield effect
 - Added CardInfo extension methods SetSteelTrapPortrait(), SetBrokenShieldPortrait()
-- Added public method TakeDamagePatches.BreakShield() for controlling DeathShield logic
-- DeathShield logic now accounts for multiple stacks (DeathShield is not stackable by default)
+- Added public method TakeDamagePatches.BreakShield() for controlling how shields are lost
+- Added public method TakeDamage.NewHasShield()
+- Added DamageShieldBehaviour for creating shield-giving abilities
+- Added support for giving cards multiple shields
+- Changed DeathShield to use a custom ability behaviour for its logic (APIDeathShield)
+- Changed DeathShield to no longer be marked as passive
+- Changed how PlayableCard.HasShield() determines whether a card has a shield or not (still uses .Status.lostShield)
+- Changed TakeDamage trigger activation to require damage > 0
+- Cards now only lose shields if damage > 0
+- Damage dealt to cards can no longer go below 0
 
 ## 2.16.1
 - Gem Shield sigil now visually applies the Armoured sigil to cards in Act 1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,14 @@
 <details>
 <summary>View Changelog</summary>
 
+## 2.17.0
+- Fixed card extension GetAbilityStacks being able to return a negative value for stackable abilities
+- Added ability interface IModifyDamageTaken
+- Added support for adding alternate portraits specific to the Steel Trap ability effect and broken shield effect
+- Added CardInfo extension methods SetSteelTrapPortrait(), SetBrokenShieldPortrait()
+- Added public method TakeDamagePatches.BreakShield() for controlling DeathShield logic
+- DeathShield logic now accounts for multiple stacks (DeathShield is not stackable by default)
+
 ## 2.16.1
 - Gem Shield sigil now visually applies the Armoured sigil to cards in Act 1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,18 +4,20 @@
 <summary>View Changelog</summary>
 
 ## 2.17.0
-- Fixed card extension GetAbilityStacks being able to return a negative value for stackable abilities
-- Added ability interfaces IModifyDamageTaken, IPreTakeDamage; both trigger at the start of the TakeDamage method
-- Added support for adding alternate portraits specific to the Steel Trap ability effect and broken shield effect
-- Added CardInfo extension methods SetSteelTrapPortrait(), SetBrokenShieldPortrait()
-- Added PlayableCard extension method ResetShield(Ability) for resetting shields belonging to a certain ability
-- Added ShieldManager for managing new shield logic, patches, and methods
+- Fixed card extension GetAbilityStacks() being able to return a negative value; minimum value is now capped at 0
+- Added ability interfaces IModifyDamageTaken, IPreTakeDamage, which trigger at the start of PlayableCard.TakeDamage
+- Added PlayableCard extension method ResetShield(Ability) for only resetting shields belonging to a certain ability
+- Added ShieldManager class and changed how shields are managed in the game's logic
 - Added abstract classes DamageShieldBehaviour and ActivatedDamageShieldBehaviour
-- Changed how shields are detected and tracked to allow for multiple shields on a card
-- DeathShield ability now has a custom AbilityBehaviour attached to it, no longer marked as passive
+- Added support for adding alternate portraits for SteelTrap activation and broken shields
+- Added portrait setters SetSteelTrapPortrait(), SetBrokenShieldPortrait(), SetPixelSteelTrapPortrait(), SetPixelBrokenShieldPortrait()
+- Added AbilityInfo extension method SetHideSingleStacks(), affecting how stacking sigils are affected by being hidden
+- DeathShield ability now has a custom AbilityBehaviour attached to it
+- DeathShield ability is no longer passive, and can stack
 - TakeDamage trigger now requires damage to be above 0 to activate
 - Cards can no longer lose shields from attacks that deal 0 damage
 - Damage dealt to cards can no longer go below 0
+- Updated the wiki with sections on the additions
 
 ## 2.16.1
 - Gem Shield sigil now visually applies the Armoured sigil to cards in Act 1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,18 +5,15 @@
 
 ## 2.17.0
 - Fixed card extension GetAbilityStacks being able to return a negative value for stackable abilities
-- Added ability interfaces IModifyDamageTaken, IPreTakeDamage
+- Added ability interfaces IModifyDamageTaken, IPreTakeDamage; both trigger at the start of the TakeDamage method
 - Added support for adding alternate portraits specific to the Steel Trap ability effect and broken shield effect
 - Added CardInfo extension methods SetSteelTrapPortrait(), SetBrokenShieldPortrait()
-- Added public method TakeDamagePatches.BreakShield() for controlling how shields are lost
-- Added public method TakeDamage.NewHasShield()
-- Added DamageShieldBehaviour for creating shield-giving abilities
-- Added support for giving cards multiple shields
-- Changed DeathShield to use a custom ability behaviour for its logic (APIDeathShield)
-- Changed DeathShield to no longer be marked as passive
-- Changed how PlayableCard.HasShield() determines whether a card has a shield or not (still uses .Status.lostShield)
-- Changed TakeDamage trigger activation to require damage > 0
-- Cards now only lose shields if damage > 0
+- Added public methods TakeDamagePatches.BreakShield() and TakeDamage.NewHasShield() - both used in the new shield logic
+- Added abstract classes DamageShieldBehaviour and ActivatedDamageShieldBehaviour
+- Changed how shields are detected and tracked to allow for multiple shields on a card
+- DeathShield ability now has a custom AbilityBehaviour attached to it, no longer marked as passive
+- TakeDamage trigger now requires damage to be above 0 to activate
+- Cards can no longer lose shields from attacks that deal 0 damage
 - Damage dealt to cards can no longer go below 0
 
 ## 2.16.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 - Cards can no longer lose shields from attacks that deal 0 damage
 - Damage dealt to cards can no longer go below 0
 - Updated the wiki with sections on the additions
+- Zombie Parrot is now part of the Avian tribe
 
 ## 2.16.1
 - Gem Shield sigil now visually applies the Armoured sigil to cards in Act 1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 
 ## 2.17.0
 - Fixed card extension GetAbilityStacks being able to return a negative value for stackable abilities
-- Added ability interface IModifyDamageTaken
+- Added ability interfaces IModifyDamageTaken, IPreTakeDamage
 - Added support for adding alternate portraits specific to the Steel Trap ability effect and broken shield effect
 - Added CardInfo extension methods SetSteelTrapPortrait(), SetBrokenShieldPortrait()
 - Added public method TakeDamagePatches.BreakShield() for controlling DeathShield logic

--- a/InscryptionAPI/Ascension/StarterDeckManager.cs
+++ b/InscryptionAPI/Ascension/StarterDeckManager.cs
@@ -67,7 +67,7 @@ public static class StarterDeckManager
 
     public static void SyncDeckList()
     {
-        var decks = BaseGameDecks.Concat(NewDecks).Select(x => CloneStarterDeck(x)).ToList();
+        var decks = BaseGameDecks.Concat(NewDecks).Select(CloneStarterDeck).ToList();
 
         foreach (var deck in decks)
         {

--- a/InscryptionAPI/Card/AbilityExtensions.cs
+++ b/InscryptionAPI/Card/AbilityExtensions.cs
@@ -375,6 +375,41 @@ public static class AbilityExtensions
     }
     #endregion
 
+    #region HideSingleStacks
+    /// <summary>
+    /// Sets an ability to only have one stack of it be hidden whenever the ability is added to a card status's hiddenAbilities field.
+    /// Adding the same ability to hiddenAbilities will hide more stacks. Only affects cards that can stack.
+    /// </summary>
+    /// <param name="abilityInfo">The instance of AbilityInfo.</param>
+    /// <param name="hideSingleStacks">Whether all stacks of this ability will be hidden when added to hiddenAbilities.</param>
+    /// <returns>The same AbilityInfo so a chain can continue.</returns>
+    public static AbilityInfo SetHideSingleStacks(this AbilityInfo abilityInfo, bool hideSingleStacks = true)
+    {
+        abilityInfo.SetExtendedProperty("HideSingleStacks", hideSingleStacks);
+        return abilityInfo;
+    }
+
+    /// <summary>
+    /// Gets the value of HideSingleStacks. Returns false if HideSingleStacks has not been set.
+    /// </summary>
+    /// <param name="abilityInfo">Ability to access.</param>
+    /// <returns>Whether single stacks of this ability will be hidden when added to hiddenAbilities.</returns>
+    public static bool GetHideSingleStacks(this Ability ability)
+    {
+        AbilityInfo abilityInfo = AllAbilityInfos.AbilityByID(ability);
+        return abilityInfo.GetHideSingleStacks();
+    }
+    /// <summary>
+    /// Gets the value of HideSingleStacks. Returns false if HideSingleStacks has not been set.
+    /// </summary>
+    /// <param name="abilityInfo">The instance of AbilityInfo.</param>
+    /// <returns>Whether single stacks of this ability will be hidden when added to hiddenAbilities.</returns>
+    public static bool GetHideSingleStacks(this AbilityInfo abilityInfo)
+    {
+        return abilityInfo.GetExtendedPropertyAsBool("HideSingleStacks") ?? false;
+    }
+    #endregion
+
     #region ExtendedProperties
 
     /// <summary>

--- a/InscryptionAPI/Card/AbilityManager.cs
+++ b/InscryptionAPI/Card/AbilityManager.cs
@@ -238,6 +238,8 @@ public static class AbilityManager
             if (name == "DeathShield")
             {
                 ability.SetPassive(false);
+                ability.SetCanStack(true);
+                ability.SetHideSingleStacks(true);
                 baseGame.Add(new FullAbility
                 (
                     null,

--- a/InscryptionAPI/Card/AbilityManager.cs
+++ b/InscryptionAPI/Card/AbilityManager.cs
@@ -235,6 +235,19 @@ public static class AbilityManager
             if (Part2ModularAbilities.BasePart2Modular.Contains(ability.ability))
                 ability.SetDefaultPart2Ability();
 
+            if (name == "DeathShield")
+            {
+                ability.SetPassive(false);
+                baseGame.Add(new FullAbility
+                (
+                    null,
+                    ability.ability,
+                    ability,
+                    typeof(APIDeathShield),
+                    useReversePatch ? OriginalLoadAbilityIcon(name) : AbilitiesUtil.LoadAbilityIcon(name)
+                ));
+                continue;
+            }
             baseGame.Add(new FullAbility
             (
                 null,

--- a/InscryptionAPI/Card/CardExtensions.cs
+++ b/InscryptionAPI/Card/CardExtensions.cs
@@ -1961,6 +1961,20 @@ public static class CardExtensions
             }
         }
 
+        var components2 = card.GetComponents<ActivatedDamageShieldBehaviour>();
+        foreach (var component in components2)
+        {
+            // stackable shields all get tallied up
+            if (AbilitiesUtil.GetInfo(component.Ability).canStack)
+                totalShields += component.NumShields;
+
+            else if (!distinct.Contains(component.Ability))
+            {
+                distinct.Add(component.Ability);
+                totalShields += component.NumShields;
+            }
+        }
+
         return totalShields;
     }
 

--- a/InscryptionAPI/Card/CardExtensions.cs
+++ b/InscryptionAPI/Card/CardExtensions.cs
@@ -1441,7 +1441,8 @@ public static class CardExtensions
     #endregion
 
     #region Extra Alts
-        /// <summary>
+    #region Pixel Alt
+    /// <summary>
     /// Sets the card's pixel alternate portrait. This portrait is used when the card is displayed in GBC mode (Act 2).
     /// </summary>
     /// <param name="info">CardInfo to access.</param>
@@ -1478,6 +1479,45 @@ public static class CardExtensions
         info.GetAltPortraits().PixelAlternatePortrait = portrait;
         return info;
     }
+    #endregion
+
+    #region Trap Alt
+    public static CardInfo SetSteelTrapPortrait(this CardInfo info, string pathToArt)
+    {
+        return info.SetSteelTrapPortrait(TextureHelper.GetImageAsTexture(pathToArt));
+    }
+    public static CardInfo SetSteelTrapPortrait(this CardInfo info, Texture2D portrait, FilterMode? filterMode = null)
+    {
+        return info.SetSteelTrapPortrait(portrait.ConvertTexture(TextureHelper.SpriteType.PixelPortrait, filterMode ?? default));
+    }
+    public static CardInfo SetSteelTrapPortrait(this CardInfo info, Sprite portrait)
+    {
+        if (!string.IsNullOrEmpty(info.name))
+            portrait.name = info.name + "_steeltrapportrait";
+
+        info.GetAltPortraits().SteelTrapPortrait = portrait;
+        return info;
+    }
+    #endregion
+
+    #region Shield Alt
+    public static CardInfo SetBrokenShieldPortrait(this CardInfo info, string pathToArt)
+    {
+        return info.SetBrokenShieldPortrait(TextureHelper.GetImageAsTexture(pathToArt));
+    }
+    public static CardInfo SetBrokenShieldPortrait(this CardInfo info, Texture2D portrait, FilterMode? filterMode = null)
+    {
+        return info.SetBrokenShieldPortrait(portrait.ConvertTexture(TextureHelper.SpriteType.PixelPortrait, filterMode ?? default));
+    }
+    public static CardInfo SetBrokenShieldPortrait(this CardInfo info, Sprite portrait)
+    {
+        if (!string.IsNullOrEmpty(info.name))
+            portrait.name = info.name + "_brokenshieldportrait";
+
+        info.GetAltPortraits().BrokenShieldPortrait = portrait;
+        return info;
+    }
+    #endregion
     #endregion
 
     #endregion
@@ -1771,7 +1811,9 @@ public static class CardExtensions
 
     public static bool HasAlternatePortrait(this PlayableCard card) => card.Info.alternatePortrait != null;
     public static bool HasAlternatePortrait(this CardInfo info) => info.alternatePortrait != null;
-    public static bool HasPixelAlternatePortrait(this CardInfo info) => info.GetAltPortraits().PixelAlternatePortrait != null;
+    public static bool HasPixelAlternatePortrait(this CardInfo info) => info.PixelAlternatePortrait() != null;
+    public static bool HasSteelTrapPortrait(this CardInfo info) => info.SteelTrapPortrait() != null;
+    public static bool HasBrokenShieldPortrait(this CardInfo info) => info.BrokenShieldPortrait() != null;
 
     /// <summary>
     /// Checks if the CardModificationInfo does not have a specific Ability.
@@ -1887,10 +1929,11 @@ public static class CardExtensions
         count += AbilitiesUtil.GetAbilitiesFromMods(card.TemporaryMods).Count(a => a == ability);
         count -= card.TemporaryMods.SelectMany(m => m.negateAbilities).Count(a => a == ability);
 
-        if (AbilitiesUtil.GetInfo(ability).canStack)
-            return count;
-        else
-            return count > 0 ? 1 : 0; // If it's not stackable, you get at most one
+        if (count <= 0)
+            return 0;
+
+        // If it's not stackable, you get at most one
+        return AbilitiesUtil.GetInfo(ability).canStack ? count : 1;
     }
 
     /// <summary>

--- a/InscryptionAPI/Card/CardExtensions.cs
+++ b/InscryptionAPI/Card/CardExtensions.cs
@@ -1937,6 +1937,34 @@ public static class CardExtensions
     }
 
     /// <summary>
+    /// Gets the number of shields the target card has. Each shield negates one damaging hit.
+    /// </summary>
+    /// <param name="card">The PlayableCard to access.</param>
+    /// <returns>The number of shields the card has.</returns>
+    public static int GetTotalShields(this PlayableCard card)
+    {
+        var components = card.GetComponents<DamageShieldBehaviour>();
+
+        int totalShields = 0;
+        List<Ability> distinct = new(); // keep track of non-stacking shield abilities
+
+        foreach (var component in components)
+        {
+            // stackable shields all get tallied up
+            if (AbilitiesUtil.GetInfo(component.Ability).canStack)
+                totalShields += component.NumShields;
+
+            else if (!distinct.Contains(component.Ability))
+            {
+                distinct.Add(component.Ability);
+                totalShields += component.NumShields;
+            }
+        }
+
+        return totalShields;
+    }
+
+    /// <summary>
     /// Check if the other PlayableCard is on the same side of the board as this PlayableCard.
     /// </summary>
     /// <param name="playableCard">The PlayableCard to access.</param>

--- a/InscryptionAPI/Card/CardExtensions.cs
+++ b/InscryptionAPI/Card/CardExtensions.cs
@@ -1488,7 +1488,7 @@ public static class CardExtensions
     }
     public static CardInfo SetSteelTrapPortrait(this CardInfo info, Texture2D portrait, FilterMode? filterMode = null)
     {
-        return info.SetSteelTrapPortrait(portrait.ConvertTexture(TextureHelper.SpriteType.PixelPortrait, filterMode ?? default));
+        return info.SetSteelTrapPortrait(portrait.ConvertTexture(TextureHelper.SpriteType.CardPortrait, filterMode ?? default));
     }
     public static CardInfo SetSteelTrapPortrait(this CardInfo info, Sprite portrait)
     {
@@ -1496,6 +1496,23 @@ public static class CardExtensions
             portrait.name = info.name + "_steeltrapportrait";
 
         info.GetAltPortraits().SteelTrapPortrait = portrait;
+        return info;
+    }
+
+    public static CardInfo SetPixelSteelTrapPortrait(this CardInfo info, string pathToArt)
+    {
+        return info.SetPixelSteelTrapPortrait(TextureHelper.GetImageAsTexture(pathToArt));
+    }
+    public static CardInfo SetPixelSteelTrapPortrait(this CardInfo info, Texture2D portrait, FilterMode? filterMode = null)
+    {
+        return info.SetPixelSteelTrapPortrait(portrait.ConvertTexture(TextureHelper.SpriteType.PixelPortrait, filterMode ?? default));
+    }
+    public static CardInfo SetPixelSteelTrapPortrait(this CardInfo info, Sprite portrait)
+    {
+        if (!string.IsNullOrEmpty(info.name))
+            portrait.name = info.name + "_pixelsteeltrapportrait";
+
+        info.GetAltPortraits().PixelSteelTrapPortrait = portrait;
         return info;
     }
     #endregion
@@ -1507,12 +1524,29 @@ public static class CardExtensions
     }
     public static CardInfo SetBrokenShieldPortrait(this CardInfo info, Texture2D portrait, FilterMode? filterMode = null)
     {
-        return info.SetBrokenShieldPortrait(portrait.ConvertTexture(TextureHelper.SpriteType.PixelPortrait, filterMode ?? default));
+        return info.SetBrokenShieldPortrait(portrait.ConvertTexture(TextureHelper.SpriteType.CardPortrait, filterMode ?? default));
     }
     public static CardInfo SetBrokenShieldPortrait(this CardInfo info, Sprite portrait)
     {
         if (!string.IsNullOrEmpty(info.name))
             portrait.name = info.name + "_brokenshieldportrait";
+
+        info.GetAltPortraits().BrokenShieldPortrait = portrait;
+        return info;
+    }
+
+    public static CardInfo SetPixelBrokenShieldPortrait(this CardInfo info, string pathToArt)
+    {
+        return info.SetPixelBrokenShieldPortrait(TextureHelper.GetImageAsTexture(pathToArt));
+    }
+    public static CardInfo SetPixelBrokenShieldPortrait(this CardInfo info, Texture2D portrait, FilterMode? filterMode = null)
+    {
+        return info.SetPixelBrokenShieldPortrait(portrait.ConvertTexture(TextureHelper.SpriteType.PixelPortrait, filterMode ?? default));
+    }
+    public static CardInfo SetPixelBrokenShieldPortrait(this CardInfo info, Sprite portrait)
+    {
+        if (!string.IsNullOrEmpty(info.name))
+            portrait.name = info.name + "_pixelbrokenshieldportrait";
 
         info.GetAltPortraits().BrokenShieldPortrait = portrait;
         return info;
@@ -1989,26 +2023,15 @@ public static class CardExtensions
         foreach (var com in card.GetComponents<DamageShieldBehaviour>())
         {
             if (com.Ability == ability)
-                com.ResetShields();
+                com.ResetShields(false);
         }
         foreach (var com in card.GetComponents<ActivatedDamageShieldBehaviour>())
         {
             if (com.Ability == ability)
-                com.ResetShields();
+                com.ResetShields(false);
         }
 
-        List<CardModificationInfo> mods = card.TemporaryMods.FindAll(x => x.GetExtendedPropertyAsBool("APINegateShield") ?? false);
-        mods.RemoveAll(x => !x.negateAbilities.Contains(ability));
-
-        List<CardModificationInfo> resetMods = new();
-        foreach (CardModificationInfo mod in mods)
-        {
-            resetMods.Add(ShieldManager.ResetShieldMod(ability));
-        }
-
-        // remove negating mods before adding new activating mods
-        card.RemoveTemporaryMods(mods.ToArray());
-        card.AddTemporaryMods(resetMods.ToArray());
+        card.ResetShield();
     }
 
     #endregion

--- a/InscryptionAPI/Card/CardManager.cs
+++ b/InscryptionAPI/Card/CardManager.cs
@@ -55,6 +55,8 @@ public static class CardManager
             card.SetBaseGameCard(true);
             if (card.name == "Squirrel" || card.name == "AquaSquirrel" || card.name == "Rabbit")
                 card.SetAffectedByTidalLock();
+            else if (card.name == "SkeletonParrot")
+                card.AddTribes(Tribe.Bird);
 
             yield return card;
         }

--- a/InscryptionAPI/Card/CardManager.cs
+++ b/InscryptionAPI/Card/CardManager.cs
@@ -25,7 +25,9 @@ public static class CardManager
     {
         public Sprite PixelAlternatePortrait = null;
         public Sprite SteelTrapPortrait = null;
+        public Sprite PixelSteelTrapPortrait = null;
         public Sprite BrokenShieldPortrait = null;
+        public Sprite PixelBrokenShieldPortrait = null;
     }
     private static readonly ConditionalWeakTable<CardInfo, CardExt> CardExtensionProperties = new();
     private static readonly ConditionalWeakTable<CardInfo, CardAltPortraits> CardAlternatePortraits = new();

--- a/InscryptionAPI/Card/CardManager.cs
+++ b/InscryptionAPI/Card/CardManager.cs
@@ -24,6 +24,8 @@ public static class CardManager
    public class CardAltPortraits
     {
         public Sprite PixelAlternatePortrait = null;
+        public Sprite SteelTrapPortrait = null;
+        public Sprite BrokenShieldPortrait = null;
     }
     private static readonly ConditionalWeakTable<CardInfo, CardExt> CardExtensionProperties = new();
     private static readonly ConditionalWeakTable<CardInfo, CardAltPortraits> CardAlternatePortraits = new();
@@ -268,6 +270,14 @@ public static class CardManager
     public static Sprite PixelAlternatePortrait(this CardInfo card)
     {
         return card.GetAltPortraits().PixelAlternatePortrait;
+    }
+    public static Sprite SteelTrapPortrait(this CardInfo card)
+    {
+        return card.GetAltPortraits().SteelTrapPortrait;
+    }
+    public static Sprite BrokenShieldPortrait(this CardInfo card)
+    {
+        return card.GetAltPortraits().BrokenShieldPortrait;
     }
 
     private const string ERROR = "ERROR";

--- a/InscryptionAPI/Card/DamageShieldBehaviour.cs
+++ b/InscryptionAPI/Card/DamageShieldBehaviour.cs
@@ -29,4 +29,10 @@ public abstract class DamageShieldBehaviour : AbilityBehaviour
 
         numShields = StartingNumShields;
     }
+
+    public void ResetShields()
+    {
+        numShields = StartingNumShields;
+        base.Card.Status.lostShield = false;
+    }
 }

--- a/InscryptionAPI/Card/DamageShieldBehaviour.cs
+++ b/InscryptionAPI/Card/DamageShieldBehaviour.cs
@@ -36,3 +36,26 @@ public abstract class DamageShieldBehaviour : AbilityBehaviour
         base.Card.Status.lostShield = false;
     }
 }
+
+public abstract class ActivatedDamageShieldBehaviour : ActivatedAbilityBehaviour
+{
+    public abstract int StartingNumShields { get; } // how many shields this sigil will provide initially
+
+    public int numShields;
+    public int NumShields => Mathf.Max(numShields, 0);
+
+    public bool HasShields() => NumShields > 0;
+
+    private void Start()
+    {
+        if (base.Card == null) return;
+
+        numShields = StartingNumShields;
+    }
+
+    public void ResetShields()
+    {
+        numShields = StartingNumShields;
+        base.Card.Status.lostShield = false;
+    }
+}

--- a/InscryptionAPI/Card/DamageShieldBehaviour.cs
+++ b/InscryptionAPI/Card/DamageShieldBehaviour.cs
@@ -1,0 +1,32 @@
+using DiskCardGame;
+using HarmonyLib;
+using InscryptionAPI.Triggers;
+using System.Runtime.CompilerServices;
+using UnityEngine;
+
+namespace InscryptionAPI.Card;
+
+
+public class APIDeathShield : DamageShieldBehaviour
+{
+    public override Ability Ability => Ability.DeathShield;
+
+    public override int StartingNumShields => 1;
+}
+
+public abstract class DamageShieldBehaviour : AbilityBehaviour
+{
+    public abstract int StartingNumShields { get; } // how many shields this sigil will provide initially
+
+    public int numShields;
+    public int NumShields => Mathf.Max(numShields, 0);
+
+    public bool HasShields() => NumShields > 0;
+
+    private void Start()
+    {
+        if (base.Card == null) return;
+
+        numShields = StartingNumShields;
+    }
+}

--- a/InscryptionAPI/Card/DamageShieldBehaviour.cs
+++ b/InscryptionAPI/Card/DamageShieldBehaviour.cs
@@ -11,7 +11,7 @@ public class APIDeathShield : DamageShieldBehaviour
 {
     public override Ability Ability => Ability.DeathShield;
 
-    public override int StartingNumShields => 1;
+    public override int StartingNumShields => base.Card.GetAbilityStacks(Ability);
 }
 
 public abstract class DamageShieldBehaviour : AbilityBehaviour
@@ -30,10 +30,22 @@ public abstract class DamageShieldBehaviour : AbilityBehaviour
         numShields = StartingNumShields;
     }
 
-    public void ResetShields()
+    public void ResetShields(bool updateDisplay)
     {
+        bool depleted = !HasShields();
         numShields = StartingNumShields;
         base.Card.Status.lostShield = false;
+
+        if (Ability.GetHideSingleStacks())
+            base.Card.Status.hiddenAbilities.RemoveAll(x => x == Ability);
+        else if (depleted)
+            base.Card.Status.hiddenAbilities.Remove(Ability);
+
+        if (updateDisplay)
+        {
+            base.Card.UpdateFaceUpOnBoardEffects();
+            base.Card.RenderCard();
+        }
     }
 }
 
@@ -53,9 +65,21 @@ public abstract class ActivatedDamageShieldBehaviour : ActivatedAbilityBehaviour
         numShields = StartingNumShields;
     }
 
-    public void ResetShields()
+    public void ResetShields(bool updateDisplay)
     {
+        bool depleted = !HasShields();
         numShields = StartingNumShields;
         base.Card.Status.lostShield = false;
+
+        if (Ability.GetHideSingleStacks())
+            base.Card.Status.hiddenAbilities.RemoveAll(x => x == Ability);
+        else if (depleted)
+            base.Card.Status.hiddenAbilities.Remove(Ability);
+
+        if (updateDisplay)
+        {
+            base.Card.UpdateFaceUpOnBoardEffects();
+            base.Card.RenderCard();
+        }
     }
 }

--- a/InscryptionAPI/Card/ShieldManager.cs
+++ b/InscryptionAPI/Card/ShieldManager.cs
@@ -1,0 +1,119 @@
+using DiskCardGame;
+using HarmonyLib;
+
+namespace InscryptionAPI.Card;
+
+[HarmonyPatch]
+public static class ShieldManager
+{
+    public static CardModificationInfo NegateShieldMod(Ability ab)
+    {
+        CardModificationInfo mod = new()
+        {
+            negateAbilities = new() { ab },
+            nonCopyable = true
+        };
+        mod.SetExtendedProperty("APINegateShield", true);
+        return mod;
+    }
+    public static CardModificationInfo ResetShieldMod(Ability ab)
+    {
+        CardModificationInfo mod = new(ab)
+        {
+            nonCopyable = true
+        };
+        mod.SetExtendedProperty("APIResetShield", true);
+        return mod;
+    }
+
+    /// <summary>
+    /// The method used for when a shielded card is damaged. Includes extra parameters for modders looking to modify this further.
+    /// This method is only called when damage > 0 and the target has a shield.
+    /// </summary>
+    public static void BreakShield(PlayableCard target, int damage, PlayableCard attacker)
+    {
+        target.Anim.StrongNegationEffect();
+
+        var components = target.GetComponents<DamageShieldBehaviour>();
+        foreach (var component in components)
+        {
+            // only reduce numShields for components with positive count
+            if (component.HasShields())
+            {
+                component.numShields--;
+
+                // if we've exhausted this shield component's count, negate it
+                // so it updates the display
+                if (component.NumShields == 0)
+                    target.AddTemporaryMod(NegateShieldMod(component.Ability));
+
+                break;
+            }
+        }
+        var components2 = target.GetComponents<ActivatedDamageShieldBehaviour>();
+        foreach (var component2 in components2)
+        {
+            // only reduce numShields for components with positive count
+            if (component2.HasShields())
+            {
+                component2.numShields--;
+
+                // if we've exhausted this shield component's count, negate it
+                // so it updates the display
+                if (component2.NumShields == 0)
+                    target.AddTemporaryMod(NegateShieldMod(component2.Ability));
+
+                break;
+            }
+        }
+
+        // if we removed the last shield
+        if (target.GetTotalShields() == 0)
+        {
+            target.Status.lostShield = true;
+
+            if (target.Info.name == "MudTurtle")
+                target.SwitchToAlternatePortrait();
+            else if (target.Info.HasBrokenShieldPortrait())
+                target.SwitchToPortrait(target.Info.BrokenShieldPortrait());
+        }
+        target.UpdateFaceUpOnBoardEffects();
+    }
+
+    [HarmonyPostfix, HarmonyPatch(typeof(PlayableCard), nameof(PlayableCard.HasShield))]
+    private static void ReplaceHasShieldBool(PlayableCard __instance, ref bool __result)
+    {
+        __result = NewHasShield(__instance);
+    }
+    public static bool NewHasShield(PlayableCard instance)
+    {
+        if (instance.GetTotalShields() > 0)
+            return !instance.Status.lostShield;
+
+        return false;
+    }
+
+    [HarmonyPrefix, HarmonyPatch(typeof(PlayableCard), nameof(PlayableCard.ResetShield))]
+    private static void ResetModShields(PlayableCard __instance)
+    {
+        foreach (var com in __instance.GetComponents<DamageShieldBehaviour>())
+            com.ResetShields();
+
+        foreach (var com in __instance.GetComponents<ActivatedDamageShieldBehaviour>())
+            com.ResetShields();
+
+        // when you negate an ability the component is removed,
+        // so we need to re-add the components when resetting the shields
+        CardModificationInfo[] mods = __instance.TemporaryMods.FindAll(x => x.GetExtendedPropertyAsBool("APINegateShield") ?? false).ToArray();
+        List<CardModificationInfo> resetMods = new();
+        foreach (CardModificationInfo mod in mods)
+        {
+            Ability ab = mod.negateAbilities[0];
+            resetMods.Add(ResetShieldMod(ab));
+        }
+
+        // remove negating mods before adding new activating mods
+        __instance.RemoveTemporaryMods(mods);
+        __instance.AddTemporaryMods(resetMods.ToArray());
+    }
+}

--- a/InscryptionAPI/Guid/CustomTypePatches.cs
+++ b/InscryptionAPI/Guid/CustomTypePatches.cs
@@ -11,7 +11,7 @@ namespace InscryptionAPI.Guid;
 [HarmonyPatch]
 public static class TypeManager
 {
-    private static Dictionary<string, Type> TypeCache = new();
+    private static readonly Dictionary<string, Type> TypeCache = new();
 
     internal static void Add(string key, Type value)
     {
@@ -34,7 +34,7 @@ public static class TypeManager
         Add(key, value);
     }
 
-    private static Dictionary<string, string> ModIds = new();
+    private static readonly Dictionary<string, string> ModIds = new();
 
     private static string GetModIdFromAssembly(Assembly assembly)
     {
@@ -53,8 +53,8 @@ public static class TypeManager
             }
         }
 
-        ModIds.Add(assembly.FullName, default(string));
-        return default(string);
+        ModIds.Add(assembly.FullName, default);
+        return default;
     }
 
     public static string GetModIdFromCallstack(Assembly callingAssembly)
@@ -63,7 +63,7 @@ public static class TypeManager
         if (!string.IsNullOrEmpty(cacheVal))
             return cacheVal;
 
-        StackTrace trace = new StackTrace();
+        StackTrace trace = new();
         foreach (var frame in trace.GetFrames())
         {
             string newVal = GetModIdFromAssembly(frame.GetMethod().DeclaringType.Assembly);
@@ -71,9 +71,8 @@ public static class TypeManager
                 return newVal;
         }
 
-        return default(string);
+        return default;
     }
-
 
     [HarmonyReversePatch(HarmonyReversePatchType.Original)]
     [HarmonyPatch(typeof(CustomType), nameof(CustomType.GetType), new Type[] { typeof(string), typeof(string) })]
@@ -92,8 +91,7 @@ public static class TypeManager
             return false;
         }
 
-        int enumValue;
-        if (int.TryParse(typeName, out enumValue))
+        if (int.TryParse(typeName, out int enumValue))
         {
             //InscryptionAPIPlugin.Logger.LogInfo($"This appears to be a custom type");
             Type enumType = GuidManager.GetEnumType(enumValue);

--- a/InscryptionAPI/InscryptionAPI.csproj
+++ b/InscryptionAPI/InscryptionAPI.csproj
@@ -10,7 +10,7 @@
         <DebugType>full</DebugType>
         <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
         <EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>
-        <Version>2.16.1</Version>
+        <Version>2.17.0</Version>
     </PropertyGroup>
 
     <ItemGroup>

--- a/InscryptionAPI/InscryptionAPIPlugin.cs
+++ b/InscryptionAPI/InscryptionAPIPlugin.cs
@@ -27,7 +27,7 @@ public class InscryptionAPIPlugin : BaseUnityPlugin
 {
     public const string ModGUID = "cyantist.inscryption.api";
     public const string ModName = "InscryptionAPI";
-    public const string ModVer = "2.16.1";
+    public const string ModVer = "2.17.0";
 
     internal static ConfigEntry<bool> configOverrideArrows;
     internal static ConfigEntry<TotemManager.TotemTopState> configCustomTotemTopTypes;

--- a/InscryptionAPI/ResourceBank/ResourceBankManager.cs
+++ b/InscryptionAPI/ResourceBank/ResourceBankManager.cs
@@ -61,7 +61,7 @@ public static class ResourceBankManager
     {
         public static void Postfix(ResourceBank __instance)
         {
-            Dictionary<string, ResourceBank.Resource> existingPaths = new Dictionary<string, ResourceBank.Resource>();
+            Dictionary<string, ResourceBank.Resource> existingPaths = new();
             foreach (ResourceBank.Resource resource in __instance.resources)
             {
                 string resourcePath = resource.path;

--- a/InscryptionAPI/Triggers/CustomTriggerPatches.cs
+++ b/InscryptionAPI/Triggers/CustomTriggerPatches.cs
@@ -184,7 +184,7 @@ internal static class CustomTriggerPatches
     private static Type takeDamageCoroutine;
     private static FieldInfo takeDamageDamage;
 
-    [HarmonyPatch(typeof(PlayableCard), nameof(PlayableCard.TakeDamage))]
+/*    [HarmonyPatch(typeof(PlayableCard), nameof(PlayableCard.TakeDamage))]
     [HarmonyPostfix]
     private static IEnumerator TriggerOnTurnEndInHandPlayer(IEnumerator result, PlayableCard __instance, int damage, PlayableCard attacker)
     {
@@ -201,7 +201,7 @@ internal static class CustomTriggerPatches
             }
         }
         yield break;
-    }
+    }*/
 
     [HarmonyPatch(typeof(ConsumableItemSlot), nameof(ConsumableItemSlot.ConsumeItem))]
     [HarmonyPostfix]

--- a/InscryptionAPI/Triggers/CustomTriggerPatches.cs
+++ b/InscryptionAPI/Triggers/CustomTriggerPatches.cs
@@ -181,28 +181,6 @@ internal static class CustomTriggerPatches
         yield break;
     }
 
-    private static Type takeDamageCoroutine;
-    private static FieldInfo takeDamageDamage;
-
-/*    [HarmonyPatch(typeof(PlayableCard), nameof(PlayableCard.TakeDamage))]
-    [HarmonyPostfix]
-    private static IEnumerator TriggerOnTurnEndInHandPlayer(IEnumerator result, PlayableCard __instance, int damage, PlayableCard attacker)
-    {
-        CustomTriggerFinder.CollectDataAll<ICardTakenDamageModifier, int>(true, x => x.RespondsToCardTakenDamageModifier(__instance, damage), x => damage = x.CollectCardTakenDamageModifier(__instance, damage));
-        if (damage != 0)
-        {
-            (takeDamageDamage ??= (takeDamageCoroutine ??= result?.GetType())?.GetField("damage"))?.SetValue(result, damage);
-            bool hasShield = __instance.HasShield();
-            yield return result;
-            if (!hasShield && attacker != null)
-            {
-                yield return CustomTriggerFinder.TriggerInHand<IOnOtherCardDealtDamageInHand>(x => x.RespondsToOtherCardDealtDamageInHand(attacker, attacker.Attack, __instance),
-                    x => x.OnOtherCardDealtDamageInHand(attacker, attacker.Attack, __instance));
-            }
-        }
-        yield break;
-    }*/
-
     [HarmonyPatch(typeof(ConsumableItemSlot), nameof(ConsumableItemSlot.ConsumeItem))]
     [HarmonyPostfix]
     private static IEnumerator TriggerItemUse(IEnumerator result, ConsumableItemSlot __instance)
@@ -355,7 +333,7 @@ internal static class CustomTriggerPatches
         bool isAttackingDefaultSlot = !__instance.HasTriStrike() && !__instance.HasAbility(Ability.SplitStrike);
         CardSlot defaultslot = __instance.Slot.opposingSlot;
 
-        List<CardSlot> alteredOpposings = new List<CardSlot>();
+        List<CardSlot> alteredOpposings = new();
         bool removeDefaultAttackSlot = false;
 
         foreach (IGetOpposingSlots component in CustomTriggerFinder.FindTriggersOnCard<IGetOpposingSlots>(__instance))
@@ -412,6 +390,8 @@ internal static class CustomTriggerPatches
     }
 
     // IModifyAttackingSlots code can be found in DoCombatPhasePatches
+
+    // IModifyDamageTaken and IPreTakeDamage logic can be found in TakeDamagePatches
 
     private static readonly Type triggerType = AccessTools.TypeByName("DiskCardGame.GlobalTriggerHandler+<TriggerCardsOnBoard>d__16");
 }

--- a/InscryptionAPI/Triggers/CustomTriggerPatches.cs
+++ b/InscryptionAPI/Triggers/CustomTriggerPatches.cs
@@ -374,7 +374,7 @@ internal static class CustomTriggerPatches
             __result.Remove(defaultslot);
         bool didRemoveOriginalSlot = __instance.HasAbility(Ability.SplitStrike) && (!__instance.HasTriStrike() || removeDefaultAttackSlot);
         var all = CustomTriggerFinder.FindGlobalTriggers<ISetupAttackSequence>(true).ToList();
-        var dummyresult = __result;
+        var dummyresult = __result; // used for sorting by trigger priority
         all.Sort((x, x2) => x.GetTriggerPriority(__instance, OpposingSlotTriggerPriority.Normal, original, dummyresult, __state, didRemoveOriginalSlot) -
             x2.GetTriggerPriority(__instance, OpposingSlotTriggerPriority.Normal, original, dummyresult, __state, didRemoveOriginalSlot));
         foreach (var opposing in all)

--- a/InscryptionAPI/Triggers/Interfaces.cs
+++ b/InscryptionAPI/Triggers/Interfaces.cs
@@ -683,5 +683,12 @@ public interface IModifyDamageTaken
 
     public int OnModifyDamageTaken(PlayableCard target, int damage, PlayableCard attacker, int originalDamage);
 
-    public int TriggerPriority(PlayableCard target, int damage, PlayableCard attacker, int originalDamage);
+    public int TriggerPriority(PlayableCard target, int damage, PlayableCard attacker);
+}
+
+public interface IPreTakeDamage
+{
+    public bool RespondsToPreTakeDamage(PlayableCard source);
+
+    public IEnumerator OnPreTakeDamage(PlayableCard source);
 }

--- a/InscryptionAPI/Triggers/Interfaces.cs
+++ b/InscryptionAPI/Triggers/Interfaces.cs
@@ -626,6 +626,7 @@ public interface IPassiveAttackBuff
 /// <summary>
 /// Data collection trigger that modifies the damage taken by any card.
 /// </summary>
+[Obsolete("Use IModifyDamageTaken instead.")]
 public interface ICardTakenDamageModifier
 {
     /// <summary>
@@ -688,7 +689,7 @@ public interface IModifyDamageTaken
 
 public interface IPreTakeDamage
 {
-    public bool RespondsToPreTakeDamage(PlayableCard source);
+    public bool RespondsToPreTakeDamage(PlayableCard source, int damage);
 
-    public IEnumerator OnPreTakeDamage(PlayableCard source);
+    public IEnumerator OnPreTakeDamage(PlayableCard source, int damage);
 }

--- a/InscryptionAPI/Triggers/Interfaces.cs
+++ b/InscryptionAPI/Triggers/Interfaces.cs
@@ -676,3 +676,12 @@ public interface IGetAttackingSlots
     /// <returns>The trigger priority int.</returns>
     public int TriggerPriority(bool playerIsAttacker, List<CardSlot> originalSlots);
 }
+
+public interface IModifyDamageTaken
+{
+    public bool RespondsToModifyDamageTaken(PlayableCard target, int damage, PlayableCard attacker, int originalDamage);
+
+    public int OnModifyDamageTaken(PlayableCard target, int damage, PlayableCard attacker, int originalDamage);
+
+    public int TriggerPriority(PlayableCard target, int damage, PlayableCard attacker, int originalDamage);
+}

--- a/InscryptionAPI/Triggers/TakeDamagePatches.cs
+++ b/InscryptionAPI/Triggers/TakeDamagePatches.cs
@@ -110,7 +110,7 @@ public static class TakeDamagePatches
                     // if (HasShield && damage > 0)
                     //   BreakShield();
 
-                    MethodBase breakShield = AccessTools.Method(typeof(TakeDamagePatches), nameof(TakeDamagePatches.BreakShield),
+                    MethodBase breakShield = AccessTools.Method(typeof(ShieldManager), nameof(ShieldManager.BreakShield),
                         new Type[] { typeof(PlayableCard), typeof(int), typeof(PlayableCard) });
 
                     codes.RemoveRange(shieldStart, shieldEnd - shieldStart);
@@ -133,113 +133,6 @@ public static class TakeDamagePatches
                 break;
             }
         }
-        //codes.LogCodeInscryptions();
         return codes;
-    }
-
-    public static void BreakShield(PlayableCard target, int damage, PlayableCard attacker)
-    {
-        // this void assumes that damage > 0
-
-        var components = target.GetComponents<DamageShieldBehaviour>();
-        foreach (var component in components)
-        {
-            // only reduce numShields for components with positive count
-            if (component.HasShields())
-            {
-                component.numShields--;
-
-                target.Anim.StrongNegationEffect();
-
-                // if we've exhausted this shield component's count, negate it
-                // so it updates the display
-                if (component.NumShields == 0)
-                {
-                    target.AddTemporaryMod(new()
-                    {
-                        negateAbilities = new() { component.Ability },
-                        nonCopyable = true
-                    });
-                }
-
-                // if we removed the last shield
-                if (target.GetTotalShields() == 0)
-                {
-                    target.Status.lostShield = true;
-
-                    if (target.Info.name == "MudTurtle")
-                        target.SwitchToAlternatePortrait();
-                    else if (target.Info.HasBrokenShieldPortrait())
-                        target.SwitchToPortrait(target.Info.BrokenShieldPortrait());
-                }
-                target.UpdateFaceUpOnBoardEffects();
-                break;
-            }
-        }
-        var components2 = target.GetComponents<ActivatedDamageShieldBehaviour>();
-        foreach (var component2 in components2)
-        {
-            // only reduce numShields for components with positive count
-            if (component2.HasShields())
-            {
-                component2.numShields--;
-
-                target.Anim.StrongNegationEffect();
-
-                // if we've exhausted this shield component's count, negate it
-                // so it updates the display
-                if (component2.NumShields == 0)
-                {
-                    target.AddTemporaryMod(new()
-                    {
-                        negateAbilities = new() { component2.Ability },
-                        nonCopyable = true
-                    });
-                }
-
-                // if we removed the last shield
-                if (target.GetTotalShields() == 0)
-                {
-                    target.Status.lostShield = true;
-
-                    if (target.Info.name == "MudTurtle")
-                        target.SwitchToAlternatePortrait();
-                    else if (target.Info.HasBrokenShieldPortrait())
-                        target.SwitchToPortrait(target.Info.BrokenShieldPortrait());
-                }
-                target.UpdateFaceUpOnBoardEffects();
-                break;
-            }
-        }
-    }
-
-    [HarmonyPostfix, HarmonyPatch(typeof(PlayableCard), nameof(PlayableCard.HasShield))]
-    private static void ReplaceHasShieldBool(PlayableCard __instance, ref bool __result)
-    {
-        __result = NewHasShield(__instance);
-    }
-    public static bool NewHasShield(PlayableCard instance)
-    {
-        if (instance.GetTotalShields() > 0)
-            return !instance.Status.lostShield;
-
-        return false;
-    }
-
-    [HarmonyPrefix, HarmonyPatch(typeof(PlayableCard), nameof(PlayableCard.ResetShield))]
-    private static void ResetModShields(PlayableCard __instance)
-    {
-        foreach (var com in __instance.GetComponents<DamageShieldBehaviour>())
-        {
-            com.ResetShields();
-            CardModificationInfo mod = __instance.TemporaryMods.Find(x => x.negateAbilities != null && x.negateAbilities.Contains(com.Ability));
-            __instance.TemporaryMods.Remove(mod);
-        }
-        foreach (var com in __instance.GetComponents<ActivatedDamageShieldBehaviour>())
-        {
-            com.ResetShields();
-            CardModificationInfo mod = __instance.TemporaryMods.Find(x => x.negateAbilities != null && x.negateAbilities.Contains(com.Ability));
-            __instance.TemporaryMods.Remove(mod);
-        }
     }
 }

--- a/InscryptionAPI/Triggers/TakeDamagePatches.cs
+++ b/InscryptionAPI/Triggers/TakeDamagePatches.cs
@@ -23,14 +23,13 @@ public static class TakeDamagePatches
     private static bool ModifyDamageTrigger(PlayableCard __instance, ref int damage, PlayableCard attacker)
     {
         int originalDamage = damage;
-        int dummy = damage;
 
         var modifyTakeDamage = CustomTriggerFinder.FindGlobalTriggers<IModifyDamageTaken>(true).ToList();
-        modifyTakeDamage.Sort((a, b) => a.TriggerPriority(__instance, dummy, attacker, originalDamage) - b.TriggerPriority(__instance, dummy, attacker, originalDamage));
+        modifyTakeDamage.Sort((a, b) => a.TriggerPriority(__instance, originalDamage, attacker) - b.TriggerPriority(__instance, originalDamage, attacker));
         foreach (var modify in modifyTakeDamage)
         {
-            if (modify.RespondsToModifyDamageTaken(__instance, damage, attacker, damage))
-              damage = modify.OnModifyDamageTaken(__instance, dummy, attacker, damage);  
+            if (modify.RespondsToModifyDamageTaken(__instance, damage, attacker, originalDamage))
+              damage = modify.OnModifyDamageTaken(__instance, damage, attacker, originalDamage);  
         }
 
         return true;
@@ -146,7 +145,8 @@ public static class TakeDamagePatches
             // negate 1 stack of death shield
             target.Info.Mods.Add(new()
             {
-                negateAbilities = new() { Ability.DeathShield }
+                negateAbilities = new() { Ability.DeathShield },
+                nonCopyable = true
             });
         }
         else

--- a/InscryptionAPI/Triggers/TakeDamagePatches.cs
+++ b/InscryptionAPI/Triggers/TakeDamagePatches.cs
@@ -1,0 +1,163 @@
+using DiskCardGame;
+using HarmonyLib;
+using InscryptionAPI.Card;
+using InscryptionAPI.Helpers;
+using InscryptionAPI.Helpers.Extensions;
+using System.Collections;
+using System.Reflection;
+using System.Reflection.Emit;
+using UnityEngine;
+
+namespace InscryptionAPI.Triggers;
+
+// Patches to DoCombatPhase that add negative damage support and modifying attack slots support
+[HarmonyPatch]
+public static class TakeDamagePatches
+{
+    private const string name_State = "System.Int32 <>1__state";
+    private const string name_Damage = "System.Int32 damage";
+    private const string name_CardAttacker = "DiskCardGame.PlayableCard attacker";
+    private const string name_CombatCurrent = "System.Object <>2__current";
+
+    [HarmonyPrefix, HarmonyPatch(typeof(PlayableCard), nameof(PlayableCard.TakeDamage))]
+    private static bool ModifyDamageTrigger(PlayableCard __instance, ref int damage, PlayableCard attacker)
+    {
+        int originalDamage = damage;
+        int dummy = damage;
+
+        var modifyTakeDamage = CustomTriggerFinder.FindGlobalTriggers<IModifyDamageTaken>(true).ToList();
+        modifyTakeDamage.Sort((a, b) => a.TriggerPriority(__instance, dummy, attacker, originalDamage) - b.TriggerPriority(__instance, dummy, attacker, originalDamage));
+        foreach (var modify in modifyTakeDamage)
+        {
+            if (modify.RespondsToModifyDamageTaken(__instance, damage, attacker, damage))
+              damage = modify.OnModifyDamageTaken(__instance, dummy, attacker, damage);  
+        }
+
+        return true;
+    }
+    [HarmonyTranspiler, HarmonyPatch(typeof(PlayableCard), nameof(PlayableCard.TakeDamage), MethodType.Enumerator)]
+    private static IEnumerable<CodeInstruction> TakeDamageTriggers(IEnumerable<CodeInstruction> instructions)
+    {
+        List<CodeInstruction> codes = new(instructions);
+
+        object current = null;
+        object state = null;
+        // Ldloc.1
+        object attacker = null;
+        object damage = null;
+
+        int startIndex = -1, endIndex = -1;
+        for (int i = 0; i < codes.Count; i++)
+        {
+            // grab the required operands, in order of appearance in the code
+            if (state == null && codes[i].operand?.ToString() == name_State)
+            {
+                state = codes[i].operand;
+                continue;
+            }
+            if (startIndex == -1 && codes[i].operand?.ToString() == "Boolean HasShield()")
+            {
+                startIndex = i + 2;
+                continue;
+            }
+            if (endIndex == -1 && codes[i].opcode == OpCodes.Br)
+            {
+                endIndex = i;
+                continue;
+            }
+            if (damage == null && codes[i].operand?.ToString() == name_Damage)
+            {
+                damage = codes[i].operand;
+                continue;
+            }
+            if (attacker == null && codes[i].operand?.ToString() == name_CardAttacker)
+            {
+                attacker = codes[i].operand;
+                continue;
+            }
+            if (current == null && codes[i].operand?.ToString() == name_CombatCurrent)
+            {
+                current = codes[i].operand;
+                if (startIndex != -1)
+                {
+                    MethodBase customMethod = AccessTools.Method(typeof(TakeDamagePatches), nameof(TakeDamagePatches.BreakShield),
+                        new Type[] { typeof(PlayableCard) });
+                    // if (HasShield)
+                    //   BreakShield();
+                    codes.RemoveRange(startIndex, endIndex - startIndex);
+                    codes.Insert(startIndex, new(OpCodes.Ldloc_1));
+                    codes.Insert(startIndex + 1, new(OpCodes.Callvirt, customMethod));
+                }
+                break;
+            }
+        }
+
+        for (int j = codes.Count - 1; j >= 0; j--)
+        {
+            if (codes[j].opcode == OpCodes.Ldc_I4_0)
+            {
+                // this.current = TriggerOtherDamageInHand
+                // this.state = 5
+                // return true
+                // this.state = -1
+
+                MethodBase customMethod = AccessTools.Method(typeof(TakeDamagePatches), nameof(TakeDamagePatches.TriggerOtherDamageInHand),
+                    new Type[] { typeof(PlayableCard), typeof(PlayableCard) });
+
+                codes.Insert(j, new(OpCodes.Ldarg_0));
+                codes.Insert(j + 1, new(OpCodes.Ldarg_0));
+                codes.Insert(j + 2, new(OpCodes.Ldloc_1));
+                codes.Insert(j + 3, new(OpCodes.Ldfld, attacker));
+                codes.Insert(j + 4, new(OpCodes.Callvirt, customMethod));
+                codes.Insert(j + 5, new(OpCodes.Stfld, current));
+
+                // this.state = 5
+                codes.Insert(j + 6, new(OpCodes.Ldarg_0));
+                codes.Insert(j + 7, new(OpCodes.Ldc_I4_5));
+                codes.Insert(j + 8, new(OpCodes.Stfld, state));
+                // return true
+                codes.Insert(j + 9, new(OpCodes.Ldc_I4_1));
+                codes.Insert(j + 10, new(OpCodes.Ret));
+                // this.state = -1
+                codes.Insert(j + 11, new(OpCodes.Ldarg_0));
+                codes.Insert(j + 12, new(OpCodes.Ldc_I4_M1));
+                codes.Insert(j + 13, new(OpCodes.Stfld, state));
+                break;
+            }
+        }
+
+        codes.LogCodeInscryptions();
+        return codes;
+    }
+    private static IEnumerator TriggerOtherDamageInHand(PlayableCard target, PlayableCard attacker)
+    {
+        yield return CustomTriggerFinder.TriggerInHand<IOnOtherCardDealtDamageInHand>(
+            x => x.RespondsToOtherCardDealtDamageInHand(attacker, attacker.Attack, target),
+            x => x.OnOtherCardDealtDamageInHand(attacker, attacker.Attack, target));
+    }
+    public static void BreakShield(PlayableCard target)
+    {
+        // is DeathShield even stackable? well whatever
+        int shieldStacks = target.GetAbilityStacks(Ability.DeathShield) - 1;
+
+        target.Anim.StrongNegationEffect();
+        if (shieldStacks > 0)
+        {
+            // negate 1 stack of death shield
+            target.Info.Mods.Add(new()
+            {
+                negateAbilities = new() { Ability.DeathShield }
+            });
+        }
+        else
+        {
+            target.Status.lostShield = true;
+
+            if (target.Info.name == "MudTurtle")
+                target.SwitchToAlternatePortrait();
+            else if (target.Info.HasBrokenShieldPortrait())
+                target.SwitchToPortrait(target.Info.BrokenShieldPortrait());
+        }
+        target.UpdateFaceUpOnBoardEffects();
+    }
+}

--- a/InscryptionAPI/Triggers/TakeDamagePatches.cs
+++ b/InscryptionAPI/Triggers/TakeDamagePatches.cs
@@ -192,7 +192,7 @@ public static class TakeDamagePatches
     }
 
     [HarmonyPrefix, HarmonyPatch(typeof(PlayableCard), nameof(PlayableCard.ResetShield))]
-    private static void ReplaceHasShieldBool(PlayableCard __instance)
+    private static void ResetModShields(PlayableCard __instance)
     {
         foreach (var com in __instance.GetComponents<DamageShieldBehaviour>())
         {

--- a/InscryptionCommunityPatch/Card/Vanilla Ability Patches/SteelTrapFix.cs
+++ b/InscryptionCommunityPatch/Card/Vanilla Ability Patches/SteelTrapFix.cs
@@ -25,8 +25,8 @@ internal class SteelTrapFix
         yield return new WaitForSeconds(0.1f);
         __instance.Card.Anim.LightNegationEffect();
 
-        if (__instance.Card.HasAlternatePortrait())
-            __instance.Card.SwitchToAlternatePortrait();
+        if (__instance.Card.Info.HasSteelTrapPortrait())
+            __instance.Card.SwitchToPortrait(__instance.Card.Info.SteelTrapPortrait());
 
         AudioController.Instance.PlaySound3D("dial_metal", MixerGroup.TableObjectsSFX, __instance.Card.transform.position);
         yield return new WaitForSeconds(0.75f);


### PR DESCRIPTION
- Fixed card extension GetAbilityStacks being able to return a negative value for stackable abilities
- Added ability interfaces IModifyDamageTaken, IPreTakeDamage
- Added support for adding alternate portraits specific to the Steel Trap ability effect and broken shield effect
- Added CardInfo extension methods SetSteelTrapPortrait(), SetBrokenShieldPortrait()
- Added public method TakeDamagePatches.BreakShield() for controlling DeathShield logic
- DeathShield logic now accounts for multiple stacks (DeathShield is not stackable by default)