### PR TITLE
Fixed Cards not being Removed when using CardManager.Remove

### DIFF
--- a/InscryptionAPI/Card/CardManager.cs
+++ b/InscryptionAPI/Card/CardManager.cs
@@ -222,7 +222,14 @@ public static class CardManager
     /// Removes a custom card from the card pool. Cannot be used to remove base game cards.
     /// </summary>
     /// <param name="card">The card to remove.</param>
-    public static void Remove(CardInfo card) => NewCards.Remove(card);
+    public static void Remove(CardInfo card)
+    {
+        if (card == null) return;
+
+        CardInfo c;
+        while ((c = NewCards.SingleOrDefault(c => c.name == card.name)) != null)
+            NewCards.Remove(c);
+    }
 
     /// <summary>
     /// Adds a new card to the card pool.


### PR DESCRIPTION
When calling `CardManager.Remove`, cards will very rarely actually be removed. Reason being that, outside of the internal API, you will almost always be working with a copy of a `CardInfo`, and never the original `CardInfo` stored in `CardManager.NewCards` (which is a private list)

All this change does is that `CardManger.Remove` now loops through all cards in `NewCards` and removes any cards with matching names, instead of only removing exact matches