### PR TITLE
FIxed sniper targeting, auto-gen tribe choice texture

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,11 @@
 <details>
 <summary>View Changelog</summary>
 
+## 2.18.4
+- Fixed Sniper sigil targeting the wrong side of the board
+- Fixed placeholder tribe choice icons being placed incorrectly
+- Auto-gen tribe choice texture is now only created if the tribe can be found in tribe choices
+
 ## 2.18.3
 - Fixed resource drone behaving incorrectly outside of Act 1
 - Added null checks to various custom triggers

--- a/InscryptionAPI/InscryptionAPI.csproj
+++ b/InscryptionAPI/InscryptionAPI.csproj
@@ -10,7 +10,7 @@
         <DebugType>full</DebugType>
         <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
         <EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>
-        <Version>2.18.3</Version>
+        <Version>2.18.4</Version>
     </PropertyGroup>
 
     <ItemGroup>

--- a/InscryptionAPI/InscryptionAPIPlugin.cs
+++ b/InscryptionAPI/InscryptionAPIPlugin.cs
@@ -27,7 +27,7 @@ public class InscryptionAPIPlugin : BaseUnityPlugin
 {
     public const string ModGUID = "cyantist.inscryption.api";
     public const string ModName = "InscryptionAPI";
-    public const string ModVer = "2.18.3";
+    public const string ModVer = "2.18.4";
 
     public static string Directory = "";
 

--- a/InscryptionAPI/TalkingCards/CustomPaperTalkingCard.cs
+++ b/InscryptionAPI/TalkingCards/CustomPaperTalkingCard.cs
@@ -7,7 +7,7 @@ using UnityEngine;
 namespace InscryptionAPI.TalkingCards;
 
 /// <summary>
-/// An abstract class for the creation of talking cards through this API.
+/// An abstract class for the creation of talking cards through the API.
 /// It inherits from PaperTalkingCard and implements ITalkingCard.
 /// </summary>
 public abstract class CustomPaperTalkingCard : PaperTalkingCard, ITalkingCard

--- a/InscryptionCommunityPatch/Card/Vanilla Ability Patches/SniperFix.cs
+++ b/InscryptionCommunityPatch/Card/Vanilla Ability Patches/SniperFix.cs
@@ -96,7 +96,7 @@ public class SniperFix
         }
     }
 
-    public static List<CardSlot> GetValidTargets(bool playerIsAttacker, CardSlot attackingSlot) => BoardManager.Instance.GetSlotsCopy(playerIsAttacker);
+    public static List<CardSlot> GetValidTargets(bool playerIsAttacker, CardSlot attackingSlot) => BoardManager.Instance.GetSlotsCopy(!playerIsAttacker);
     public static void PlayerTargetSelectedCallback(List<CardSlot> opposingSlots, CardSlot targetSlot, CardSlot attackingSlot)
     {
         opposingSlots.Add(targetSlot);

--- a/InscryptionCommunityPatch/ResourceManagers/ActOneEnergyDrone.cs
+++ b/InscryptionCommunityPatch/ResourceManagers/ActOneEnergyDrone.cs
@@ -23,7 +23,7 @@ public static class EnergyDrone
     public static bool SceneCanHaveEnergyDrone(string sceneName)
     {
         string activeSceneName = sceneName.ToLowerInvariant();
-        return activeSceneName.Contains("part1") || activeSceneName.Contains("magnificus") || activeSceneName.Contains("grimora");
+        return (activeSceneName.Contains("part1") && !activeSceneName.Contains("sanctum")) || activeSceneName.Contains("magnificus") || activeSceneName.Contains("grimora");
     }
 
     public static bool CurrentSceneCanHaveEnergyDrone

--- a/docs/wiki/talking_cards.md
+++ b/docs/wiki/talking_cards.md
@@ -242,7 +242,7 @@ Here's an example:
 ```
 "You must be... [w:0.4][c:#7f35e6]confused[c:][w:1].",
 ```
-In this example, the word "confused" is colored in the color #7f35e6. Which, if you don't wanna look it up, is [this color!](https://g.co/kgs/JPHV5v)
+In this example, the word "confused" is colored in the color #7f35e6. Which, if you don't wanna look it up, it's [this color!](https://g.co/kgs/JPHV5v)
 
 Please note that for compatibility reasons, your hex color code **should include the '#'**.
 


### PR DESCRIPTION
Made an oopsie when expanding sniper logic. Also fixed the auto-gen tribe choice texture being A) off-centre, and B) able to wrap the tribe icon texture around due to a lack of constraints