### PR TITLE
2.19.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,29 @@
 <details>
 <summary>View Changelog</summary>
 
-# 2.18.8
+# 2.19.0
+- Fixed decals added via temporary mods not being cleared from the base card
+- Fixed merged and totem sigils being uninteractable if the icon has been flipped vertically
+- Fixed pixel Shapeshifter patch not correctly patching DisguiseOutOfBattle
+- Fixed temporary decal mods not being removed in Act 1
+- Fixed softlock in Part 1 during the boon-gaining sequence
+- Fixed all copies of a custom challenge becoming activated/deactivated when the page is reloaded
+- Fixed Sentry ability softlocking when the base card dies before all Sentry stacks are triggered
+- Fixed softlock when talking card dialogue cannot be parsed in certain conditions
+- Added public method GetIjiraqDisguises to pixel Shapeshifter patch for easier modification of Shapeshifter for modders
 - Added variant of PeltManager.New
-- PeltManager.New (both versions) now throws an error when getCardChoices is null
+- Added variant of PlayableCard.AllAbilities that accounts for negated abilities in TemporaryMods
+- Added support for creating custom card costs using new class CustomCardCost; see wiki for more information
+- Added ability to remove gems costs from a card using CardModificationInfos
+- Added a number of extension methods for CardModificationInfos (RemoveGemsCost, SetCustomCostId, etc)
+- Added helpers for getting TextBox.Style from CardInfo.temple or the chosen ambition
+- Rewrote CardModificationInfoManager's id system for setting persistent extended properties in a CardModificationInfo's singletonId
+- Rewrote pixel Shapeshifter patch to RevealInBattle to hopefully prevent errors in Act 1
+- PeltManager.New now throws an error when getCardChoices is null
+- Changed LogLevel of dialogue event insertion message from Info to Debug
+- API death cards now use the clean singleton id when creating the death card info mod
+- Temporary decal mods are now removed from Act 2 cards instead of being cleared
+- Opponent snipers will now target a random slot if there are no opposing cards (previously only targeted the opposing slot)
 
 # 2.18.7
 - Fixed softlock during Act 1's final boss cabin/boons sequence 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 <details>
 <summary>View Changelog</summary>
 
+# 2.18.8
+- Added variant of PeltManager.New
+- PeltManager.New (both versions) now throws an error when getCardChoices is null
+
 # 2.18.7
 - Fixed softlock during Act 1's final boss cabin/boons sequence 
 - Fixed startup errors relating to ShieldManager transpilers

--- a/InscryptionAPI/Ascension/AscensionChallengePaginatorSetupifier.cs
+++ b/InscryptionAPI/Ascension/AscensionChallengePaginatorSetupifier.cs
@@ -3,6 +3,7 @@ using UnityEngine;
 
 namespace InscryptionAPI.Ascension;
 
+// adding this comment to say that setupifier is a ridiculous word, very fun
 public class AscensionChallengePaginatorSetupifier : ManagedBehaviour
 {
     public void Start()

--- a/InscryptionAPI/Ascension/AscensionChallengeScreen.cs
+++ b/InscryptionAPI/Ascension/AscensionChallengeScreen.cs
@@ -130,9 +130,8 @@ internal static class AscensionChallengeScreenPatches
         return true;
     }
 
-    [HarmonyPatch(typeof(AscensionMenuScreens), "Start")]
-    [HarmonyPostfix]
-    public static void Postfix(AscensionMenuScreens __instance)
+    [HarmonyPostfix, HarmonyPatch(typeof(AscensionMenuScreens), "Start")]
+    private static void AddPaginatorSetupifierToMenuScreens(AscensionMenuScreens __instance)
     {
         if (__instance.challengeUnlockSummaryScreen != null && __instance.challengeUnlockSummaryScreen.GetComponent<AscensionMenuScreenTransition>() != null &&
             __instance.challengeUnlockSummaryScreen.GetComponent<AscensionChallengePaginatorSetupifier>() == null)
@@ -142,11 +141,9 @@ internal static class AscensionChallengeScreenPatches
         }
     }
 
-    [HarmonyPatch(typeof(AscensionChallengeScreen), "Start")]
-    [HarmonyPostfix]
-    public static void Postfix(AscensionChallengeScreen __instance)
+    [HarmonyPostfix, HarmonyPatch(typeof(AscensionChallengeScreen), "Start")]
+    private static void AddPaginatorToChallengeScreen(AscensionChallengeScreen __instance)
     {
-        Debug.Log($"{AscensionSaveData.Data.activeChallenges.Count}");
         if (__instance.GetComponent<AscensionChallengePaginator>() == null)
         {
             ChallengeManager.SyncChallengeList();

--- a/InscryptionAPI/Card/AbilityManager.cs
+++ b/InscryptionAPI/Card/AbilityManager.cs
@@ -97,7 +97,6 @@ public static class AbilityManager
             BaseRulebookDescription = info.rulebookDescription;
 
             ReverseMapper.Add(info, this);
-
             TypeManager.Add(id.ToString(), behaviour);
         }
 

--- a/InscryptionAPI/Card/CardExtensionsCosts.cs
+++ b/InscryptionAPI/Card/CardExtensionsCosts.cs
@@ -79,7 +79,7 @@ public static partial class CardExtensions
     /// </summary>
     public static List<GemType> GemsCost(this PlayableCard card)
     {
-        if (!card || !card.Info)
+        if (card?.Info == null)
             return new();
 
         List<CardModificationInfo> mods = card.TemporaryMods.Concat(card.Info.Mods).ToList();
@@ -90,13 +90,18 @@ public static partial class CardExtensions
         List<GemType> gemsCost = new(card.Info.gemsCost);
         foreach (CardModificationInfo mod in mods)
         {
-            if (mod.addGemCost == null)
-                continue;
-
-            foreach (GemType item in mod.addGemCost)
+            if (mod.addGemCost != null)
             {
-                if (!gemsCost.Contains(item))
-                    gemsCost.Add(item);
+                foreach (GemType item in mod.addGemCost)
+                {
+                    if (!gemsCost.Contains(item))
+                        gemsCost.Add(item);
+                }
+            }
+            foreach (GemType gem in mod.RemovedGemsCosts())
+            {
+                if (gemsCost.Contains(gem))
+                    gemsCost.Remove(gem);
             }
         }
 

--- a/InscryptionAPI/Card/CardExtensionsHelpers.cs
+++ b/InscryptionAPI/Card/CardExtensionsHelpers.cs
@@ -326,6 +326,27 @@ public static partial class CardExtensions
     {
         return playableCard.GetAbilitiesFromAllMods().Concat(playableCard.Info.Abilities).ToList();
     }
+    /// <summary>
+    /// A variant of PlayableCard.AllAbilities that can account for negated abilities in the PlayableCard's TemporaryMods.
+    /// </summary>
+    /// <param name="playableCard">The PlayableCard to access.</param>
+    /// <param name="accountForNegation">Whether or not to check TemporaryMods for negated abilities.</param>
+    /// <returns>A list of Abilities from the PlayableCard and underlying CardInfo object</returns>
+    public static List<Ability> AllAbilities(this PlayableCard playableCard, bool accountForNegation)
+    {
+        List<Ability> retval = playableCard.AllAbilities();
+        if (!accountForNegation)
+            return retval;
+
+        playableCard.TemporaryMods.ForEach(delegate (CardModificationInfo m)
+        {
+            m.negateAbilities?.ForEach(delegate (Ability a)
+            {
+                retval.Remove(a);
+            });
+        });
+        return retval;
+    }
 
     /// <summary>
     /// Retrieve a list of all CardModificationInfos that exist on the PlayableCard.

--- a/InscryptionAPI/Card/DeathCardManager.cs
+++ b/InscryptionAPI/Card/DeathCardManager.cs
@@ -69,8 +69,9 @@ public static class DeathCardManager
             .SetOnePerDeck();
 
         newInfo.animatedPortrait = CardLoader.GetCardByName("!DEATHCARD_BASE").animatedPortrait;
-        newInfo.Mods.Add(new() { singletonId = mod.singletonId, deathCardInfo = mod.deathCardInfo });
+        newInfo.Mods.Add(new() { singletonId = mod.CleanId(), deathCardInfo = mod.deathCardInfo });
 
+        // set the custom costs to the card info
         foreach (string customCost in CardModificationInfoManager.GetCustomCostsFromId(mod.singletonId))
         {
             string[] splitCost = customCost.Split(',');

--- a/InscryptionAPI/Costs/CardCostManager.cs
+++ b/InscryptionAPI/Costs/CardCostManager.cs
@@ -1,0 +1,320 @@
+using DiskCardGame;
+using GBC;
+using HarmonyLib;
+using InscryptionAPI.Card;
+using InscryptionAPI.Dialogue;
+using InscryptionAPI.Guid;
+using InscryptionAPI.Helpers;
+using InscryptionAPI.Nodes;
+using Pixelplacement.TweenSystem;
+using Sirenix.Utilities;
+using System;
+using System.Collections;
+using System.Collections.ObjectModel;
+using System.Reflection;
+using System.Reflection.Emit;
+using System.Runtime.CompilerServices;
+using UnityEngine;
+
+namespace InscryptionAPI.CardCosts;
+
+/*public class TestCost : CustomCardCost
+{
+    public override string CostName => "TestCost";
+
+    public static void Init()
+    {
+        CardCostManager.FullCardCost fullCardCost = CardCostManager.Register("api", "TestCost", typeof(TestCost), F, F);
+    }
+
+    public static Texture2D F(int cardCost, CardInfo info, PlayableCard playableCard)
+    {
+        return Texture2D.blackTexture;
+    }
+
+    public override bool CostSatisfied(int cardCost, PlayableCard card)
+    {
+        return cardCost <= (Singleton<ResourcesManager>.Instance.PlayerEnergy - card.EnergyCost);
+    }
+
+    public override string CostUnsatisfiedHint(int cardCost, PlayableCard card)
+    {
+        return "Eat your greens aby. " + card.Info.DisplayedNameLocalized;
+    }
+
+    public override IEnumerator OnPlayed(int cardCost, PlayableCard card)
+    {
+        yield return Singleton<ResourcesManager>.Instance.SpendEnergy(cardCost);
+    }
+}*/
+
+[HarmonyPatch]
+public static class CardCostManager
+{
+    public class FullCardCost
+    {
+        public string ModGUID;
+        public string CostName;
+
+        public Type CostBehaviour;
+
+        /// <summary>
+        /// Retrieves the correct texture corresponding to CardInfo's cost. Used in the 3D Acts (Act 1, Act 3, etc.).
+        /// Parameters:
+        ///     int: how much of the custom cost the CardInfo/PlayableCard needs to be played.
+        ///     CardInfo: the base CardInfo of the current card.
+        ///     PlayableCard: the PlayableCard possessing the base CardInfo. Can be null.
+        /// Returns:
+        ///     The texture representing the custom cost to display on the card.
+        /// </summary>
+        public Func<int, CardInfo, PlayableCard, Texture2D> GetCostTexture;
+        /// <summary>
+        /// Retrieves the correct texture corresponding to CardInfo's cost. Used in Act 2.
+        /// Parameters:
+        ///     int: how much of the custom cost the CardInfo/PlayableCard needs to be played.
+        ///     CardInfo: the base CardInfo of the current card.
+        ///     PlayableCard: the PlayableCard possessing the base CardInfo. Can be null.
+        /// Returns:
+        ///     The texture representing the custom cost to display on the card.
+        /// </summary>
+        public Func<int, CardInfo, PlayableCard, Texture2D> GetPixelCostTexture;
+
+        public Func<CardInfo, int> GetCostTier;
+
+        public FullCardCost(string modGUID, string costName, Type costBehaviour,
+            Func<int, CardInfo, PlayableCard, Texture2D> getCostTexture,
+            Func<int, CardInfo, PlayableCard, Texture2D> getPixelCostTexture)
+        {
+            ModGUID = modGUID;
+            CostName = costName;
+            CostBehaviour = costBehaviour;
+            GetCostTexture = getCostTexture;
+            GetPixelCostTexture = getPixelCostTexture;
+
+            TypeManager.Add(costName, costBehaviour);
+        }
+
+        public FullCardCost Clone()
+        {
+            FullCardCost retval = new(this.ModGUID, this.CostName, this.CostBehaviour, this.GetCostTexture, this.GetPixelCostTexture);
+            return retval;
+        }
+    }
+
+    static CardCostManager()
+    {
+        NewCosts.CollectionChanged += static (_, _) =>
+        {
+            SyncCustomCostList();
+        };
+    }
+
+    public static List<FullCardCost> AllCustomCosts { get; private set; } = new();
+
+    internal readonly static ObservableCollection<FullCardCost> NewCosts = new();
+    
+    public static event Func<List<FullCardCost>, List<FullCardCost>> ModifyCustomCostList;
+    public static void SyncCustomCostList()
+    {
+        AllCustomCosts = NewCosts.Select(a => a.Clone()).ToList();
+        AllCustomCosts = ModifyCustomCostList?.Invoke(AllCustomCosts) ?? AllCustomCosts;
+    }
+
+    public static FullCardCost Register(string modGUID, string costName, Type costBehaviour,
+        Func<int, CardInfo, PlayableCard, Texture2D> getCostTexture, Func<int, CardInfo, PlayableCard, Texture2D> getPixelCostTexture)
+    {
+        FullCardCost newCost = new(modGUID, costName, costBehaviour, getCostTexture, getPixelCostTexture);
+        NewCosts.Add(newCost);
+        return newCost;
+    }
+
+    #region Patches
+    [HarmonyPostfix, HarmonyPatch(typeof(PlayableCard), nameof(PlayableCard.CanPlay))]
+    private static void CanPlayCustomCosts(ref bool __result, ref PlayableCard __instance)
+    {
+        if (__result)
+        {
+            foreach (CustomCardCost cost in __instance.GetCustomCardCosts())
+            {
+                __result = __result && cost.CostSatisfied(__instance.GetCustomCost(cost.CostName), __instance);
+                if (!__result)
+                    break;
+            }
+        }
+    }
+
+    [HarmonyPrefix, HarmonyPatch(typeof(HintsHandler), nameof(HintsHandler.OnNonplayableCardClicked))]
+    private static bool CannotAffordCustomCostHints(ref PlayableCard card)
+    {
+        if (SaveManager.SaveFile.IsPart2)
+        {
+            foreach (CustomCardCost customCost in card.GetCustomCardCosts())
+            {
+                int value = card.GetCustomCost(customCost.CostName);
+                if (!customCost.CostSatisfied(value, card))
+                {
+                    CustomCoroutine.Instance.StartCoroutine(TextBox.Instance.ShowUntilInput(
+                        customCost.CostUnsatisfiedHint(value, card),
+                        DialogueManager.GetStyleFromAmbition())
+                        );
+                    return false;
+                }
+            }
+        }
+        else if (TextDisplayer.m_Instance != null)
+        {
+            foreach (CustomCardCost customCost in card.GetCustomCardCosts())
+            {
+                int value = card.GetCustomCost(customCost.CostName);
+                if (!customCost.CostSatisfied(value, card))
+                {
+                    if (customCost.PlayHintFrequency > 0 && customCost.playHintAttempts % customCost.PlayHintFrequency == 0)
+                    {
+                        CustomCoroutine.Instance.StartCoroutine(TextDisplayer.Instance.ShowUntilInput(
+                                customCost.CostUnsatisfiedHint(value, card))
+                            );
+                    }
+                    customCost.playHintAttempts++;
+                    return false;
+                }
+            }
+        }
+        return true;
+    }
+
+    [HarmonyPrefix, HarmonyPatch(typeof(DiskCardGame.Card), nameof(DiskCardGame.Card.SetInfo))]
+    private static void AttachCustomCardCosts(DiskCardGame.Card __instance, CardInfo info)
+    {
+        // destroy all pre-existing card costs
+        __instance.GetComponents<CustomCardCost>().ForEach(x => UnityObject.Destroy(x));
+
+        foreach (Type type in info.GetCustomCosts().Select(x => x.CostBehaviour))
+        {
+            __instance.gameObject.AddComponent(type);
+            //InscryptionAPIPlugin.Logger.LogInfo($"AddCost: {type.Name}");
+        }
+    }
+
+    #region SelectedCardToSlot transiler
+    [HarmonyTranspiler, HarmonyPatch(typeof(PlayerHand), nameof(PlayerHand.SelectSlotForCard), MethodType.Enumerator)]
+    private static IEnumerable<CodeInstruction> FixDialogueSoftlock(IEnumerable<CodeInstruction> instructions)
+    {
+        List<CodeInstruction> codes = new(instructions);
+        //codes.LogCodeInscryptions();
+
+        int methodIndex = codes.FindIndex(x => x.opcode == OpCodes.Callvirt && x.operand.ToString() == "System.Collections.IEnumerator PlayCardOnSlot(DiskCardGame.PlayableCard, DiskCardGame.CardSlot)");
+        if (methodIndex > 0)
+        {
+            MethodInfo newPlayCardToSlot = AccessTools.Method(typeof(CardCostManager), nameof(CardCostManager.PlaySelectedCardToSlot),
+                new Type[] { typeof(PlayerHand), typeof(PlayableCard), typeof(CardSlot) });
+
+            codes[methodIndex] = new(OpCodes.Callvirt, newPlayCardToSlot);
+            //InscryptionAPIPlugin.Logger.LogInfo($"Added PlaySelectedCardToSlot");
+        }
+
+        // offset to the start of the ilcode we want to remove
+        int bonesIndex = codes.FindIndex(x => x.opcode == OpCodes.Callvirt && x.operand.ToString() == "Int32 get_BonesCost()") - 3;
+        if (bonesIndex > 0)
+        {
+            int endIndex = codes.FindIndex(bonesIndex, x => x.opcode == OpCodes.Ldc_I4_6) + 4; // offset to the end of the code to remove
+            codes.RemoveRange(bonesIndex, endIndex - bonesIndex);
+            //InscryptionAPIPlugin.Logger.LogInfo("Removed dupe bone code");
+        }
+        int energyIndex = codes.FindIndex(x => x.opcode == OpCodes.Callvirt && x.operand.ToString() == "Int32 get_EnergyCost()") - 2;
+        if (energyIndex > 0)
+        {
+            int endIndex = codes.FindIndex(energyIndex, x => x.opcode == OpCodes.Ldc_I4_7) + 4;
+            codes.RemoveRange(energyIndex, endIndex - energyIndex);
+            //InscryptionAPIPlugin.Logger.LogInfo($"Removed dupe energy code");
+        }
+        return codes;
+    }
+    /// <summary>
+    /// Does two things:
+    ///     1: Caches play costs before playing the card onto the board to prevent incorrect values being used should the card's info change.
+    ///     2: Implements support for custom cards' OnPlay logic.
+    /// </summary>
+    /// <param name="instance">The PlayerHand object.</param>
+    /// <param name="card">The PlayableCard being played to the board.</param>
+    /// <param name="lastSelectedSlot">The last selected slot, equals BoardManage.Instance.LastSelectedSlot by default.</param>
+    /// <returns></returns>
+    public static IEnumerator PlaySelectedCardToSlot(PlayerHand instance, PlayableCard card, CardSlot lastSelectedSlot)
+    {
+        // keep track of the costs before the card is resolved on the board
+        // this is to avoid situations where the card's info changes before we can actually spend resources
+        // which would cause us to spend the incorrect amount or type
+        int bonesCost = card.BonesCost(), energyCost = card.EnergyCost;
+        Dictionary<string, int> customCosts = new();
+        foreach (CustomCardCost cost1 in card.GetCustomCardCosts())
+            customCosts.Add(cost1.CostName, card.GetCustomCost(cost1.CostName));
+
+        yield return instance.PlayCardOnSlot(card, lastSelectedSlot);
+
+        if (bonesCost > 0)
+            yield return Singleton<ResourcesManager>.Instance.SpendBones(bonesCost);
+
+        if (energyCost > 0)
+            yield return Singleton<ResourcesManager>.Instance.SpendEnergy(energyCost);
+
+        foreach (var cost2 in card.GetCustomCardCosts())
+        {
+            if (customCosts.ContainsKey(cost2.CostName))
+                yield return cost2.OnPlayed(customCosts[cost2.CostName], card);
+        }
+    }
+    #endregion
+
+    #endregion
+}
+
+/// <summary>
+/// An inheritable class for implementing custom card costs.
+/// </summary>
+public abstract class CustomCardCost : ManagedBehaviour
+{
+    /// <summary>
+    /// The internal name of the cost. Used to check for the cost's extended property by the API.
+    /// </summary>
+    public abstract string CostName { get; }
+    public virtual int PlayHintFrequency { get; } = 1;
+    public int playHintAttempts = 0;
+
+    /// <summary>
+    /// Whether the current PlayableCard can be played.
+    /// </summary>
+    /// <param name="cardCost">How many of this cost the PlayableCard needs in order to be played.</param>
+    /// <param name="playableCard">The PlayableCard currently being checked.</param>
+    public virtual bool CostSatisfied(int cardCost, PlayableCard playableCard)
+    {
+        return true;
+    }
+    /// <summary>
+    /// The dialogue string that will be played when you cannot play a card with this custom cost.
+    /// </summary>
+    /// <param name="cardCost">How many of this cost the PlayableCard needs in order to be played.</param>
+    /// <param name="playableCard">The PlayableCard currently being checked.</param>
+    public virtual string CostUnsatisfiedHint(int cardCost, PlayableCard playableCard)
+    {
+        return null;
+    }
+    /// <summary>
+    /// The (stat point) SP value of the custom cost. Used in a few places by the game to determine how powerful a card can be, (eg Build-A-Card).
+    /// </summary>
+    /// <param name="cardCost">How many of this cost the PlayableCard needs in order to be played.</param>
+    /// <param name="playableCard">The PlayableCard currently being checked.</param>
+    public virtual int CostStatPointValue(int cardCost, PlayableCard playableCard)
+    {
+        return 0;
+    }
+
+    /// <summary>
+    /// What the game should do when a card with this cost is played.
+    /// Most common use case is implementing the logic for paying for this cost.
+    /// </summary>
+    /// <param name="cardCost">How many of this cost the PlayableCard needs in order to be played.</param>
+    /// <param name="playableCard">The PlayableCard currently being checked.</param>
+    public virtual IEnumerator OnPlayed(int cardCost, PlayableCard playableCard)
+    {
+        yield break;
+    }
+}

--- a/InscryptionAPI/Dialogue/DialogueManager.cs
+++ b/InscryptionAPI/Dialogue/DialogueManager.cs
@@ -23,9 +23,9 @@ public static class DialogueManager
         public string PluginGUID;
     }
 
-    public static List<Dialogue> CustomDialogue = new List<Dialogue>();
-    public static List<DialogueColor> CustomDialogueColor = new List<DialogueColor>();
-    public static Dictionary<string, Color> ColorLookup = new Dictionary<string, Color>();
+    public static List<Dialogue> CustomDialogue = new();
+    public static List<DialogueColor> CustomDialogueColor = new();
+    public static Dictionary<string, Color> ColorLookup = new();
 
     public static Dialogue Add(string pluginGUID, DialogueEvent dialogueEvent)
     {
@@ -90,6 +90,10 @@ public static class DialogueManager
         return GenerateEvent(pluginGUID, "Region" + regionName, lines, repeatLines);
     }
 
+    /// <summary>
+    /// A version of PlayDialogueEvent that can be used in the 3D Acts as well as Act 2.
+    /// Effectively just adds a check for Act 2 and then runs the correct PlayDialogueEvent method.
+    /// </summary>
     public static IEnumerator PlayDialogueEventSafe(string eventId,
         MessageAdvanceMode advanceMode = MessageAdvanceMode.Auto,
         EventIntersectMode intersectMode = EventIntersectMode.Wait,
@@ -106,6 +110,37 @@ public static class DialogueManager
         else
         {
             yield return TextDisplayer.Instance.PlayDialogueEvent(eventId, advanceMode, intersectMode, variableStrings, newLineCallback);
+        }
+    }
+
+    /// <summary>
+    /// A quick method to convert a card's CardTemple into the respective TextBox.Style.
+    /// </summary>
+    /// <param name="temple">The CardTemple we want to use.</param>
+    /// <returns>The corresponding TextBox.Style.</returns>
+    public static TextBox.Style GetStyleFromTemple(CardTemple temple) => (TextBox.Style)(int)temple;
+
+    /// <summary>
+    /// A method to grab the correct TextBox.Style based off the player's chosen ambition.
+    /// </summary>
+    /// <returns>The corresponding TextBox.Style.</returns>
+    public static TextBox.Style GetStyleFromAmbition()
+    {
+        if (StoryEventsData.EventCompleted(StoryEvent.GBCUndeadAmbition))
+        {
+            return TextBox.Style.Undead;
+        }
+        else if (StoryEventsData.EventCompleted(StoryEvent.GBCNatureAmbition))
+        {
+            return TextBox.Style.Nature;
+        }
+        else if (StoryEventsData.EventCompleted(StoryEvent.GBCTechAmbition))
+        {
+            return TextBox.Style.Tech;
+        }
+        else
+        {
+            return TextBox.Style.Magic;
         }
     }
 

--- a/InscryptionAPI/InscryptionAPI.csproj
+++ b/InscryptionAPI/InscryptionAPI.csproj
@@ -10,7 +10,7 @@
         <DebugType>full</DebugType>
         <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
         <EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>
-        <Version>2.18.7</Version>
+        <Version>2.18.8</Version>
     </PropertyGroup>
 
     <ItemGroup>

--- a/InscryptionAPI/InscryptionAPI.csproj
+++ b/InscryptionAPI/InscryptionAPI.csproj
@@ -10,7 +10,7 @@
         <DebugType>full</DebugType>
         <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
         <EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>
-        <Version>2.18.8</Version>
+        <Version>2.19.0</Version>
     </PropertyGroup>
 
     <ItemGroup>

--- a/InscryptionAPI/InscryptionAPIPlugin.cs
+++ b/InscryptionAPI/InscryptionAPIPlugin.cs
@@ -6,6 +6,7 @@ using BepInEx.Logging;
 using DiskCardGame;
 using HarmonyLib;
 using InscryptionAPI.Card;
+using InscryptionAPI.CardCosts;
 using InscryptionAPI.Dialogue;
 using InscryptionAPI.Encounters;
 using InscryptionAPI.Items;
@@ -27,7 +28,7 @@ public class InscryptionAPIPlugin : BaseUnityPlugin
 {
     public const string ModGUID = "cyantist.inscryption.api";
     public const string ModName = "InscryptionAPI";
-    public const string ModVer = "2.18.8";
+    public const string ModVer = "2.19.0";
 
     public static string Directory = "";
 
@@ -74,6 +75,7 @@ public class InscryptionAPIPlugin : BaseUnityPlugin
     internal static void ResyncAll()
     {
         CardManager.SyncCardList();
+        CardCostManager.SyncCustomCostList();
         CardModificationInfoManager.SyncCardMods();
         AbilityManager.SyncAbilityList();
         EncounterManager.SyncEncounterList();
@@ -117,7 +119,7 @@ public class InscryptionAPIPlugin : BaseUnityPlugin
         CardManager.AuditCardList();
         PixelCardManager.Initialise();
         PeltManager.CreateDialogueEvents();
-        Logger.LogInfo($"Inserted {DialogueManager.CustomDialogue.Count} dialogue event(s)!");
+        Logger.LogDebug($"Inserted {DialogueManager.CustomDialogue.Count} dialogue event(s)!");
     }
 
     [HarmonyPatch(typeof(AscensionMenuScreens), nameof(AscensionMenuScreens.TransitionToGame))]

--- a/InscryptionAPI/InscryptionAPIPlugin.cs
+++ b/InscryptionAPI/InscryptionAPIPlugin.cs
@@ -27,7 +27,7 @@ public class InscryptionAPIPlugin : BaseUnityPlugin
 {
     public const string ModGUID = "cyantist.inscryption.api";
     public const string ModName = "InscryptionAPI";
-    public const string ModVer = "2.18.7";
+    public const string ModVer = "2.18.8";
 
     public static string Directory = "";
 

--- a/InscryptionAPI/PixelCard/PixelCardManager.cs
+++ b/InscryptionAPI/PixelCard/PixelCardManager.cs
@@ -51,16 +51,12 @@ public static class PixelCardManager // code courtesy of Nevernamed and James/ke
         if (SaveManager.SaveFile.IsPart2)
             __result = __instance.GetComponentInParent<DiskCardGame.Card>();
     }
-    [HarmonyPatch(typeof(PixelBoardManager), nameof(PixelBoardManager.CleanUp))]
-    [HarmonyPostfix]
+    [HarmonyPostfix, HarmonyPatch(typeof(PixelBoardManager), nameof(PixelBoardManager.CleanUp))]
     private static IEnumerator ClearTempDecals(IEnumerator enumerator)
     {
         foreach (CardInfo info in SaveManager.SaveFile.gbcData.deck.Cards)
         {
-            foreach (CardModificationInfo mod in info.Mods.Where(x => x.IsTemporaryDecal()))
-            {
-                mod.DecalIds.Clear();
-            }
+            info.Mods.RemoveAll(x => x.IsTemporaryDecal());
         }
         yield return enumerator;
     }

--- a/InscryptionCommunityPatch/Card/BoxColliderNegativeScalingLogSpamFix.cs
+++ b/InscryptionCommunityPatch/Card/BoxColliderNegativeScalingLogSpamFix.cs
@@ -28,7 +28,7 @@ internal class BoxColliderNegativeScalingLogSpamFix
 
         MeshCollider collider = __instance.gameObject.GetComponent<MeshCollider>();
         MeshFilter filter = __instance.gameObject.GetComponent<MeshFilter>();
-        if (collider.SafeIsUnityNull() && !filter.SafeIsUnityNull())
+        if (collider == null && filter != null)
         {
             UnityObject.Destroy(__instance.GetComponent<BoxCollider>());
 
@@ -52,11 +52,11 @@ internal class BoxColliderNegativeScalingLogSpamFix
         // This was the missing piece.
         // The collider box when the MeshCollider is added ends up being right under the card, therefore unable to click.
         // Adjusting the y-position here to be higher up allows the icon to be right-clickable again.
-        collider.transform.position += new Vector3(0, 0.1f, 0);
+        collider.transform.localPosition = new Vector3(collider.transform.localPosition.x, collider.transform.localPosition.y, -0.1f);
     }
 
     [HarmonyPostfix, HarmonyPatch(typeof(CardAbilityIcons), nameof(CardAbilityIcons.PositionModIcons))]
-    private static void ReadjustFlippedMergePosition(
+    private static void ReadjustFlippedMergePosition(CardAbilityIcons __instance,
     List<Ability> defaultAbilities,
     List<Ability> mergeAbilities, List<AbilityIconInteractable> mergeIcons,
     List<Ability> totemAbilities, List<AbilityIconInteractable> totemIcons
@@ -68,14 +68,18 @@ internal class BoxColliderNegativeScalingLogSpamFix
         // fixes flipped merged/totem sigils being uninteractable if they're placed in the centre of the card
         if (mergeAbilities.Count == 1 && mergeIcons.Count > 0)
         {
-            if (!mergeIcons[0].transform.GetComponent<MeshCollider>().SafeIsUnityNull())
-                mergeIcons[0].transform.position += new Vector3(0f, 0.1f, 0f);
+            if (mergeIcons[0].transform.GetComponent<MeshCollider>() != null && AbilitiesUtil.GetInfo(mergeAbilities[0]).flipYIfOpponent)
+            {
+                mergeIcons[0].transform.localPosition = new Vector3(__instance.DefaultIconPosition.x, __instance.DefaultIconPosition.y, -0.1f);
+            }
         }
 
         else if (totemAbilities.Count == 1 && totemIcons.Count > 0)
         {
-            if (!totemIcons[0].transform.GetComponent<MeshCollider>().SafeIsUnityNull())
-                totemIcons[0].transform.position += new Vector3(0f, 0.1f, 0f);
+            if (totemIcons[0].transform.GetComponent<MeshCollider>() != null && AbilitiesUtil.GetInfo(mergeAbilities[0]).flipYIfOpponent)
+            {
+                totemIcons[0].transform.localPosition = new Vector3(__instance.DefaultIconPosition.x, __instance.DefaultIconPosition.y, -0.1f);
+            }
         }
     }
 }

--- a/InscryptionCommunityPatch/Card/CardCostRender.cs
+++ b/InscryptionCommunityPatch/Card/CardCostRender.cs
@@ -1,0 +1,87 @@
+using DiskCardGame;
+using GBC;
+using HarmonyLib;
+using InscryptionAPI.Card;
+using InscryptionAPI.CardCosts;
+//using InscryptionAPI.CardCosts;
+using InscryptionAPI.Helpers;
+using UnityEngine;
+
+namespace InscryptionCommunityPatch.Card;
+
+[HarmonyPatch]
+public static class CardCostRender
+{
+    internal static readonly Dictionary<string, Texture2D> AssembledTextures = new();
+
+    /// <summary>
+    /// Grabs the texture associated with the given key if it has already been assembled.
+    /// Otherwise, creates the texture using the provided string and returns it.
+    /// </summary>
+    /// <param name="key"></param>
+    public static Texture2D GetTextureByName(string key)
+    {
+        if (AssembledTextures.ContainsKey(key))
+        {
+            if (AssembledTextures[key] != null)
+                return AssembledTextures[key];
+
+            AssembledTextures.Remove(key); // remove null textures
+        }
+
+        Texture2D texture = TextureHelper.GetImageAsTexture($"{key}.png", typeof(CardCostRender).Assembly);
+        AssembledTextures.Add(key, texture);
+        return texture;
+    }
+
+    /// <summary>
+    /// Creates a sprite that combines all of a card's play costs.
+    /// </summary>
+    public static Sprite FinalCostSprite(CardInfo cardInfo, PlayableCard playableCard, TextureHelper.SpriteType spriteType, int yStep)
+    {
+        Texture2D baseTexture;
+        List<Texture2D> masterTextures;
+        
+        int bloodCost = playableCard?.BloodCost() ?? cardInfo.BloodCost;
+        int bonesCost = playableCard?.BonesCost() ?? cardInfo.BonesCost;
+        int energyCost = playableCard?.EnergyCost ?? cardInfo.EnergyCost;
+        List<GemType> gemsCost = playableCard?.GemsCost() ?? cardInfo.GemsCost;
+
+        bool pixelCard = spriteType != TextureHelper.SpriteType.OversizedCostDecal;
+        if (pixelCard)
+        {
+            baseTexture = TextureHelper.GetImageAsTexture("pixel_base.png", typeof(CardCostRender).Assembly);
+            masterTextures = Part2CardCostRender.CostTextures(cardInfo, playableCard, bloodCost, bonesCost, energyCost, gemsCost);
+        }
+        else
+        {
+            baseTexture = TextureHelper.GetImageAsTexture("empty_cost.png", typeof(CardCostRender).Assembly);
+            masterTextures = Part1CardCostRender.CostTextures(cardInfo, playableCard, bloodCost, bonesCost, energyCost, gemsCost);
+        }
+
+        while (masterTextures.Count < 4)
+            masterTextures.Add(null);
+
+        Texture2D combinedTexture = TextureHelper.CombineTextures(masterTextures, baseTexture, yStep: yStep);
+        return TextureHelper.ConvertTexture(combinedTexture, spriteType);
+    }
+
+    [HarmonyPostfix, HarmonyPatch(typeof(CardDisplayer), nameof(CardDisplayer.DisplayInfo))]
+    private static void CreateFullCostSprite(CardDisplayer __instance, CardRenderInfo renderInfo, PlayableCard playableCard)
+    {
+        // DisplayNull will have already been called, so we just return
+        if (renderInfo?.baseInfo == null || __instance.costRenderer == null)
+            return;
+
+        // don't just check for IsPart1/Part2 since pixel cards can appear in Act 1 (starter deck screen)
+        if (__instance is CardDisplayer3D)
+        {
+            __instance.costRenderer.sprite = FinalCostSprite(renderInfo.baseInfo, playableCard, TextureHelper.SpriteType.OversizedCostDecal, 28);
+        }
+        else if (__instance is PixelCardDisplayer && PatchPlugin.act2CostRender.Value)
+        {
+            __instance.costRenderer.sprite = FinalCostSprite(renderInfo.baseInfo, playableCard,
+                PatchPlugin.rightAct2Cost.Value ? TextureHelper.SpriteType.Act2CostDecalRight : TextureHelper.SpriteType.Act2CostDecalLeft, 8);
+        }
+    }
+}

--- a/InscryptionCommunityPatch/Card/HiddenCharIndexFIx.cs
+++ b/InscryptionCommunityPatch/Card/HiddenCharIndexFIx.cs
@@ -1,0 +1,25 @@
+using DiskCardGame;
+using GBC;
+using HarmonyLib;
+using System.Collections;
+using UnityEngine;
+
+namespace InscryptionCommunityPatch.Card;
+
+[HarmonyPatch]
+internal class HiddenCharIndexFIx
+{
+    [HarmonyPatch(typeof(SequentialText), nameof(SequentialText.RemoveFirstHiddenChar))]
+    [HarmonyPrefix]
+    private static bool CheckForNegativeIndex(SequentialText __instance, ref int __result)
+    {
+        int num = __instance.GetText().IndexOf("<color=#00000000>");
+        if (num != -1)
+            __instance.SetText(__instance.GetText().Remove(num, 26));
+        else
+            num = 0;
+
+        __result = num;
+        return false;
+    }
+}

--- a/InscryptionCommunityPatch/Card/Part1CardCostRender.cs
+++ b/InscryptionCommunityPatch/Card/Part1CardCostRender.cs
@@ -1,120 +1,116 @@
 using DiskCardGame;
+using GBC;
 using HarmonyLib;
 using InscryptionAPI.Card;
+using InscryptionAPI.CardCosts;
+//using InscryptionAPI.CardCosts;
 using InscryptionAPI.Helpers;
 using UnityEngine;
 
 namespace InscryptionCommunityPatch.Card;
 
-[HarmonyPatch]
+//[HarmonyPatch]
+/// <summary>
+/// Modifies how card costs are rendered in Act to add support for mixed card costs, custom costs, and energy and Mox costs.
+/// </summary>
 public static class Part1CardCostRender
 {
-    // This patches the way card costs are rendered in Act 1 (Leshy's cabin)
-    // It allows mixed card costs to display correctly (i.e., 2 blood, 1 bone)
-    // And allows gem cost and energy cost to render on the card at all.
-
     public static event Action<CardInfo, List<Texture2D>> UpdateCardCost;
 
-    private static readonly Dictionary<string, Texture2D> AssembledTextures = new();
-
-    public const int COST_OFFSET = 28;
-
-    public const int MOX_OFFSET = 21;
-
-    public static Texture2D CombineCostTextures(List<Texture2D> costs)
+    public static List<Texture2D> CostTextures(CardInfo cardInfo, PlayableCard playableCard, int bloodCost, int bonesCost, int energyCost, List<GemType> gemsCost)
     {
-        while (costs.Count < 4)
-            costs.Add(null);
-        Texture2D baseTexture = TextureHelper.GetImageAsTexture("empty_cost.png", typeof(Part1CardCostRender).Assembly);
-        return TextureHelper.CombineTextures(costs, baseTexture, yStep: COST_OFFSET);
-    }
+        List<Texture2D> costTextures = new();
 
-    public static Texture2D CombineMoxTextures(List<Texture2D> costs)
-    {
-        Texture2D baseTexture = TextureHelper.GetImageAsTexture("mox_cost_empty.png", typeof(Part1CardCostRender).Assembly);
-        return TextureHelper.CombineTextures(costs, baseTexture, xStep: MOX_OFFSET);
-    }
-
-    private static Texture2D GetTextureByName(string key)
-    {
-        if (AssembledTextures.ContainsKey(key))
-        {
-            if (AssembledTextures[key] != null)
-                return AssembledTextures[key];
-
-            AssembledTextures.Remove(key);
-        }
-
-        Texture2D texture = TextureHelper.GetImageAsTexture($"{key}.png", typeof(Part1CardCostRender).Assembly);
-        AssembledTextures.Add(key, texture);
-        return texture;
-    }
-
-    public static Sprite Part1SpriteFinal(CardInfo cardInfo)
-    {
-        PlayableCard playableCard = cardInfo.GetPlayableCard();
-
-        // A list to hold the textures (important later, to combine them all)
-        List<Texture2D> list = new();
-
-        // Setting mox first
-        List<GemType> gemsCost = playableCard?.GemsCost() ?? cardInfo.GemsCost;
         if (gemsCost.Count > 0)
         {
-            // Make a new list for the mox textures
+            // Get all the Mox textures, with placeholders if less than 3 Mox are present
             List<Texture2D> gemCost = new();
 
-            // Add all moxes to the gemcost list
             if (gemsCost.Contains(GemType.Green))
-                gemCost.Add(GetTextureByName("mox_cost_g"));
+                gemCost.Add(CardCostRender.GetTextureByName("mox_cost_g"));
 
             if (gemsCost.Contains(GemType.Blue))
-                gemCost.Add(GetTextureByName("mox_cost_b"));
+                gemCost.Add(CardCostRender.GetTextureByName("mox_cost_b"));
 
             if (gemsCost.Contains(GemType.Orange))
-                gemCost.Add(GetTextureByName("mox_cost_o"));
+                gemCost.Add(CardCostRender.GetTextureByName("mox_cost_o"));
 
             while (gemCost.Count < 3)
                 gemCost.Insert(0, null);
 
-            // Combine the textures into one
-            list.Add(CombineMoxTextures(gemCost));
+            costTextures.Add(TextureHelper.CombineTextures(gemCost, TextureHelper.GetImageAsTexture("mox_cost_empty.png", typeof(Part1CardCostRender).Assembly), xStep: 21));
         }
 
-        int energyCost = playableCard?.EnergyCost ?? cardInfo.EnergyCost;
-        if (energyCost > 0) // there's 6+ texture but since Energy can't go above 6 normally I have excluded it from consideration
-            list.Add(GetTextureByName($"energy_cost_{Mathf.Min(6, energyCost)}"));
+        // there's a 6+ texture but since Energy can't go above 6 normally I have excluded it from consideration
+        if (energyCost > 0)
+            costTextures.Add(CardCostRender.GetTextureByName($"energy_cost_{Mathf.Min(6, energyCost)}"));
 
-        int bonesCost = playableCard?.BonesCost() ?? cardInfo.BonesCost;
         if (bonesCost > 0)
-            list.Add(GetTextureByName($"bone_cost_{Mathf.Min(14, bonesCost)}"));
+            costTextures.Add(CardCostRender.GetTextureByName($"bone_cost_{Mathf.Min(14, bonesCost)}"));
 
-        int bloodCost = playableCard?.BloodCost() ?? cardInfo.BloodCost;
         if (bloodCost > 0)
-            list.Add(GetTextureByName($"blood_cost_{Mathf.Min(14, bloodCost)}"));
+            costTextures.Add(CardCostRender.GetTextureByName($"blood_cost_{Mathf.Min(14, bloodCost)}"));
+
+        // get a list of the custom costs we need textures for
+        // check for PlayableCard to account for possible dynamic costs (no API support but who knows what modders do)
+        List<CardCostManager.FullCardCost> customCosts;
+        if (playableCard != null)
+            customCosts = playableCard.GetCustomCardCosts().Select(x => CardCostManager.AllCustomCosts.Find(c => c.CostName == x.CostName)).ToList();
+        else
+            customCosts = cardInfo.GetCustomCosts();
+
+        foreach (CardCostManager.FullCardCost fullCost in customCosts)
+        {
+            string key = fullCost.CostName + cardInfo.GetCustomCost(fullCost.CostName);
+            if (CardCostRender.AssembledTextures.ContainsKey(key))
+            {
+                if (CardCostRender.AssembledTextures[key] != null)
+                    costTextures.Add(CardCostRender.AssembledTextures[key]);
+                else
+                    CardCostRender.AssembledTextures.Remove(key);
+            }
+            else
+            {
+                Texture2D costTex = fullCost.GetCostTexture?.Invoke(cardInfo.GetCustomCost(fullCost.CostName), cardInfo, playableCard);
+                if (costTex != null)
+                {
+                    costTextures.Add(costTex);
+                    CardCostRender.AssembledTextures.Add(key, costTex);
+                }
+            }
+        }
 
         // Call the event and allow others to modify the list of textures
-        UpdateCardCost?.Invoke(cardInfo, list);
-
-        // Combine all the textures from the list into one texture
-        Texture2D finalTexture = CombineCostTextures(list);
-
-        // Convert the final texture to a sprite
-        return TextureHelper.ConvertTexture(finalTexture, TextureHelper.SpriteType.OversizedCostDecal);
+        UpdateCardCost?.Invoke(cardInfo, costTextures);
+        return costTextures;
     }
 
-    [HarmonyPatch(typeof(CardDisplayer), nameof(CardDisplayer.GetCostSpriteForCard))]
-    [HarmonyPrefix]
-    private static bool Part1CardCostDisplayerPatch(ref Sprite __result, CardDisplayer __instance, CardInfo card)
+    /*#region old
+    public const int MOX_OFFSET = 21;
+
+    public static Texture2D CombineMoxTextures(List<Texture2D> costs) => null;
+
+    public static Texture2D CombineCostTextures(List<Texture2D> costs)
     {
-        //Make sure we are in Leshy's Cabin
+        return null;
+        while (costs.Count < 4)
+            costs.Add(null);
+
+        Texture2D baseTexture = TextureHelper.GetImageAsTexture("empty_cost.png", typeof(Part1CardCostRender).Assembly);
+        return TextureHelper.CombineTextures(costs, baseTexture, yStep: COST_OFFSET);
+    }
+
+    [HarmonyPrefix, HarmonyPatch(typeof(CardDisplayer), nameof(CardDisplayer.SetCostSprite))]
+    private static bool Part1And2CardCostDisplayerPatch(CardDisplayer __instance)
+    {
+        // Make sure we are in Leshy's Cabin
         if (__instance is CardDisplayer3D && SceneLoader.ActiveSceneName.StartsWith("Part1"))
-        {
-            // Set the results as the new sprite
-            __result = Part1SpriteFinal(card);
             return false;
-        }
         
+        else if (__instance is PixelCardDisplayer && PatchPlugin.act2CostRender.Value)
+            return false;
+
         return true;
     }
+    #endregion*/
 }

--- a/InscryptionCommunityPatch/Card/Part2CardCostRender.cs
+++ b/InscryptionCommunityPatch/Card/Part2CardCostRender.cs
@@ -1,22 +1,112 @@
 using DiskCardGame;
 using GBC;
 using HarmonyLib;
+using InscryptionAPI;
+using InscryptionAPI.Card;
+using InscryptionAPI.CardCosts;
 using InscryptionAPI.Helpers;
 using UnityEngine;
 
 namespace InscryptionCommunityPatch.Card;
 
-[HarmonyPatch]
+//[HarmonyPatch]
+/// <summary>
+/// Modifies how card costs are rendered in Act 2 to add support for mixed costs and custom costs.
+/// Also reduces the size of card costs so they take up less space on the card.
+/// </summary>
 public static class Part2CardCostRender
 {
-    // This patches the way card costs are rendered in Act 2 (GBC)
-    // It allows mixed card costs to display correctly (i.e., 2 blood, 1 bone)
-    // And makes the card costs take up a smaller amount of space on the card, showing off more art.
-    // Also allows for custom costs to hook in and be displayed without the creator needing to patch cost render
-
     public static event Action<CardInfo, List<Texture2D>> UpdateCardCost;
-
     public static bool RightAct2Cost => PatchPlugin.rightAct2Cost.Value;
+
+    public static List<Texture2D> CostTextures(CardInfo cardInfo, PlayableCard playableCard, int bloodCost, int bonesCost, int energyCost, List<GemType> gemsCost)
+    {
+        List<Texture2D> costTextures = new();
+
+        if (bloodCost > 0)
+            costTextures.Add(CombineIconAndCount(bloodCost, CardCostRender.GetTextureByName("pixel_blood")));
+
+        if (bonesCost > 0)
+            costTextures.Add(CombineIconAndCount(bonesCost, CardCostRender.GetTextureByName("pixel_bone")));
+
+        if (energyCost > 0)
+            costTextures.Add(CombineIconAndCount(energyCost, CardCostRender.GetTextureByName("pixel_energy")));
+
+        if (gemsCost.Count > 0)
+        {
+            List<Texture2D> gemCost = new();
+
+            // Order of: green, orange, blue
+            if (gemsCost.Contains(GemType.Green))
+                gemCost.Add(CardCostRender.GetTextureByName("pixel_mox_green"));
+
+            if (gemsCost.Contains(GemType.Orange))
+                gemCost.Add(CardCostRender.GetTextureByName("pixel_mox_orange"));
+
+            if (gemsCost.Contains(GemType.Blue))
+                gemCost.Add(CardCostRender.GetTextureByName("pixel_mox_blue"));
+
+            if (RightAct2Cost)
+                gemCost.Reverse();
+
+            Texture2D blankPixel = TextureHelper.GetImageAsTexture("pixel_blank.png", typeof(Part2CardCostRender).Assembly);
+            costTextures.Add(TextureHelper.CombineTextures(gemCost, blankPixel, xOffset: !RightAct2Cost ? 0 : (30 - 7 * gemCost.Count), xStep: 7));
+        }
+
+        // get a list of the custom costs we need textures for
+        // check for PlayableCard to account for possible dynamic costs (no API support but who knows what modders do)
+        List<CardCostManager.FullCardCost> customCosts;
+        if (playableCard != null)
+            customCosts = playableCard.GetCustomCardCosts().Select(x => CardCostManager.AllCustomCosts.Find(c => c.CostName == x.CostName)).ToList();
+        else
+            customCosts = cardInfo.GetCustomCosts();
+
+        foreach (CardCostManager.FullCardCost fullCost in customCosts)
+        {
+            string key = fullCost.CostName + cardInfo.GetCustomCost(fullCost.CostName);
+            if (CardCostRender.AssembledTextures.ContainsKey(key))
+            {
+                if (CardCostRender.AssembledTextures[key] != null)
+                    costTextures.Add(CardCostRender.AssembledTextures[key]);
+                else
+                    CardCostRender.AssembledTextures.Remove(key);
+            }
+            else
+            {
+                Texture2D costTex = fullCost.GetPixelCostTexture?.Invoke(cardInfo.GetCustomCost(fullCost.CostName), cardInfo, playableCard);
+                if (costTex != null)
+                {
+                    costTextures.Add(costTex);
+                    CardCostRender.AssembledTextures.Add(key, costTex);
+                }
+            }
+        }
+
+        // Call the event and allow others to modify the list of textures
+        UpdateCardCost?.Invoke(cardInfo, costTextures);
+        return costTextures;
+    }
+
+    public static Texture2D CombineIconAndCount(int cardCost, Texture2D artCost)
+    {
+        //string key = 
+        List<Texture2D> list = new();
+        if (cardCost <= 4)
+        {
+            for (int i = 0; i < cardCost; i++)
+                list.Add(artCost);
+        }
+        else
+        {
+            list.Add(artCost);
+            list.Add(CardCostRender.GetTextureByName("pixel_L_{cardCost}"));
+        }
+
+        int xOffset = !RightAct2Cost ? 0 : cardCost >= 10 ? 30 - 20 - artCost.width : cardCost <= 4 ? 30 - artCost.width * cardCost : 30 - 14 - artCost.width;
+        return TextureHelper.CombineTextures(list, TextureHelper.GetImageAsTexture("pixel_blank.png", typeof(Part2CardCostRender).Assembly), xOffset: xOffset, xStep: artCost.width);
+    }
+
+    /*#region old
     public static Texture2D BlankPixelCost() => TextureHelper.GetImageAsTexture("pixel_blank.png", typeof(Part2CardCostRender).Assembly);
 
     public static Texture2D CombineIconAndCount(int cardCost, Texture2D artCost)
@@ -41,28 +131,33 @@ public static class Part2CardCostRender
     {
         // A list to hold the textures (important later, to combine them all)
         List<Texture2D> masterList = new();
+        PlayableCard playableCard = card.GetPlayableCard();
 
-        if (card.BloodCost > 0)
-            masterList.Add(CombineIconAndCount(card.BloodCost, TextureHelper.GetImageAsTexture("pixel_blood.png", typeof(Part2CardCostRender).Assembly)));
+        int bloodCost = playableCard?.BloodCost() ?? card.BloodCost;
+        if (bloodCost > 0)
+            masterList.Add(CombineIconAndCount(bloodCost, TextureHelper.GetImageAsTexture("pixel_blood.png", typeof(Part2CardCostRender).Assembly)));
 
-        if (card.BonesCost > 0)
-            masterList.Add(CombineIconAndCount(card.BonesCost, TextureHelper.GetImageAsTexture("pixel_bone.png", typeof(Part2CardCostRender).Assembly)));
+        int bonesCost = playableCard?.BonesCost() ?? card.BonesCost;
+        if (bonesCost > 0)
+            masterList.Add(CombineIconAndCount(bonesCost, TextureHelper.GetImageAsTexture("pixel_bone.png", typeof(Part2CardCostRender).Assembly)));
 
-        if (card.EnergyCost > 0)
-            masterList.Add(CombineIconAndCount(card.EnergyCost, TextureHelper.GetImageAsTexture("pixel_energy.png", typeof(Part2CardCostRender).Assembly)));
+        int energyCost = playableCard?.EnergyCost ?? card.EnergyCost;
+        if (energyCost > 0)
+            masterList.Add(CombineIconAndCount(energyCost, TextureHelper.GetImageAsTexture("pixel_energy.png", typeof(Part2CardCostRender).Assembly)));
 
-        if (card.GemsCost.Count > 0)
+        List<GemType> gemsCost = playableCard?.GemsCost() ?? card.GemsCost;
+        if (gemsCost.Count > 0)
         {
             List<Texture2D> gemCost = new();
 
             // Order of: green, orange, blue
-            if (card.GemsCost.Contains(GemType.Green))
+            if (gemsCost.Contains(GemType.Green))
                 gemCost.Add(TextureHelper.GetImageAsTexture("pixel_mox_green.png", typeof(Part2CardCostRender).Assembly));
 
-            if (card.GemsCost.Contains(GemType.Orange))
+            if (gemsCost.Contains(GemType.Orange))
                 gemCost.Add(TextureHelper.GetImageAsTexture("pixel_mox_orange.png", typeof(Part2CardCostRender).Assembly));
 
-            if (card.GemsCost.Contains(GemType.Blue))
+            if (gemsCost.Contains(GemType.Blue))
                 gemCost.Add(TextureHelper.GetImageAsTexture("pixel_mox_blue.png", typeof(Part2CardCostRender).Assembly));
 
             if (RightAct2Cost)
@@ -70,6 +165,25 @@ public static class Part2CardCostRender
 
             masterList.Add(TextureHelper.CombineTextures(gemCost, BlankPixelCost(),
                 xOffset: !RightAct2Cost ? 0 : (30 - 7 * gemCost.Count), xStep: 7));
+        }
+
+        if (playableCard != null)
+        {
+            foreach (CustomCardCost customCost in playableCard.GetCustomCardCosts())
+            {
+                Texture2D costTex = customCost.GetPixelCostTexture(playableCard.GetCustomCost(customCost.CostName), card, playableCard, false);
+                if (costTex != null)
+                    masterList.Add(costTex);
+            }
+        }
+        else
+        {
+            foreach (CardCostManager.FullCardCost fullCost in card.GetCustomCosts())
+            {
+                Texture2D costTex = fullCost.GetPixelCostTextureFallback?.Invoke(card.GetCustomCost(fullCost.CostName), card);
+                if (costTex != null)
+                    masterList.Add(costTex);
+            }
         }
 
         // Call the event and allow others to modify the list of textures
@@ -83,22 +197,7 @@ public static class Part2CardCostRender
         Texture2D finalTexture = TextureHelper.CombineTextures(masterList, baseTexture, yStep: 8);
 
         //Convert the final texture to a sprite
-        Sprite finalSprite = TextureHelper.ConvertTexture(finalTexture, !RightAct2Cost ? TextureHelper.SpriteType.Act2CostDecalLeft : TextureHelper.SpriteType.Act2CostDecalRight);
-        return finalSprite;
+        return TextureHelper.ConvertTexture(finalTexture, !RightAct2Cost ? TextureHelper.SpriteType.Act2CostDecalLeft : TextureHelper.SpriteType.Act2CostDecalRight);
     }
-
-    [HarmonyPatch(typeof(CardDisplayer), nameof(CardDisplayer.GetCostSpriteForCard))]
-    [HarmonyPrefix]
-    private static bool Part2CardCostDisplayerPatch(ref Sprite __result, ref CardInfo card, ref CardDisplayer __instance)
-    {
-        // Make sure we are only modifying pixel cards
-        if (__instance is PixelCardDisplayer && PatchPlugin.act2CostRender.Value)
-        {
-            // Set the results as the new sprite
-            __result = Part2SpriteFinal(card);
-            return false;
-        }
-
-        return true;
-    }
+    #endregion*/
 }

--- a/InscryptionCommunityPatch/Card/Vanilla Ability Patches/AllStrikeAbilityFix.cs
+++ b/InscryptionCommunityPatch/Card/Vanilla Ability Patches/AllStrikeAbilityFix.cs
@@ -12,7 +12,7 @@ public class AllStrikeAbilityFix
 {
     private static IEnumerable<CodeInstruction> Transpiler(IEnumerable<CodeInstruction> instructions)
     {
-        int startIndex = -1, endIndex = -1;
+        int startIndex = -1;
         List<CodeInstruction> codes = new List<CodeInstruction>(instructions);
 
         for (int i = 0; i < codes.Count; i++)

--- a/InscryptionCommunityPatch/Card/Vanilla Ability Patches/SentryInteractionFixes.cs
+++ b/InscryptionCommunityPatch/Card/Vanilla Ability Patches/SentryInteractionFixes.cs
@@ -36,6 +36,9 @@ public class SentryInteractionFixes
     // Fixes Sentry not triggering OnCardGettingAttacked and freezing
     public static IEnumerator NewFireAtOpposingSlot(Sentry instance, PlayableCard otherCard)
     {
+        if (instance.Card == null)
+            yield break;
+
         // Copy otherCard so we can change it later
         PlayableCard opposingCard = otherCard;
 

--- a/InscryptionCommunityPatch/Card/Vanilla Ability Patches/SniperFix.cs
+++ b/InscryptionCommunityPatch/Card/Vanilla Ability Patches/SniperFix.cs
@@ -150,7 +150,7 @@ public class SniperFix
                     return noPref.Slot;
             }
         }
-        return attackingSlot.opposingSlot;
+        return opposingSlots[SeededRandom.Range(0, opposingSlots.Count, SaveManager.SaveFile.GetCurrentRandomSeed() + Singleton<GlobalTriggerHandler>.Instance.NumTriggersThisBattle)];
     }
     public static List<T> GetSorted<T>(List<T> unsorted, Comparison<T> sort)
     {

--- a/InscryptionCommunityPatch/PixelTutor/PixelPlayableCardArray.cs
+++ b/InscryptionCommunityPatch/PixelTutor/PixelPlayableCardArray.cs
@@ -18,7 +18,6 @@ public class PixelPlayableCardArray : ManagedBehaviour
     public readonly List<PixelPlayableCard> displayedCards = new();
 
     private PixelPlayableCard gameObjectReference = null;
-    private GenericUIButton buttonReference = null;
     private GameObject overlay;
     private GenericUIButton forwardButton = null;
     private GenericUIButton backButton = null;
@@ -40,6 +39,8 @@ public class PixelPlayableCardArray : ManagedBehaviour
     public IEnumerator DisplayUntilCancelled(List<CardInfo> cards,
         Func<bool> cancelCondition, Action cardsPlacedCallback = null)
     {
+        //Debug.Log($"{cards.Exists(x => x == null)}");
+        cards.RemoveAll(x => x == null);
         currentPageIndex = 0;
         numPages = 1 + (cards.Count - 1) / (maxCardsPerRow * maxRows);
         InitializeGamepadGrid();
@@ -63,6 +64,9 @@ public class PixelPlayableCardArray : ManagedBehaviour
         List<CardInfo> cards, Action<PixelPlayableCard> cardSelectedCallback,
         Func<bool> cancelCondition = null, bool forPositiveEffect = true)
     {
+        //Debug.Log($"{cards.Exists(x => x == null)}");
+        cards.RemoveAll(x => x == null);
+
         currentPageIndex = 0;
         numPages = 1 + (cards.Count - 1) / (maxCardsPerRow * maxRows);
         if (cards.Count == 0)
@@ -242,6 +246,11 @@ public class PixelPlayableCardArray : ManagedBehaviour
         });
         displayedCards.Clear();
 
+        if (numRows <= 0)
+        {
+            PatchPlugin.Logger.LogDebug($"NumRows for PixelPlayableCardArray is 0, displaying no cards");
+            yield break;
+        }
         // can only show 42 cards per page
         int maxPerPage = maxRows * maxCardsPerRow;
         int startingIndex = maxPerPage * pageIndex;

--- a/InscryptionCommunityPatch/ResourceManagers/ActOneEnergyDrone.cs
+++ b/InscryptionCommunityPatch/ResourceManagers/ActOneEnergyDrone.cs
@@ -173,7 +173,13 @@ public static class EnergyDrone
 
         return false;
     }
-    
+    [HarmonyPrefix, HarmonyPatch(typeof(ResourceDrone), nameof(ResourceDrone.UpdateCellAndGemColors))]
+    private static bool DisableUpdateWhenNull()
+    {
+        if (ResourcesManager.m_Instance == null)
+            return false;
+        return true;
+    }
     [HarmonyPatch(typeof(Part1ResourcesManager), nameof(Part1ResourcesManager.CleanUp))]
     [HarmonyPrefix]
     private static void Part1ResourcesManager_CleanUp(Part1ResourcesManager __instance)

--- a/InscryptionCommunityPatch/ResourceManagers/ActOneEnergyDrone.cs
+++ b/InscryptionCommunityPatch/ResourceManagers/ActOneEnergyDrone.cs
@@ -15,9 +15,9 @@ public static class EnergyDrone
     {
         public bool ConfigEnergy => PoolHasEnergy || PatchPlugin.configEnergy.Value;
         public bool ConfigDrone => PoolHasEnergy || ConfigDroneMox || PatchPlugin.configDrone.Value;
-        public bool ConfigDefaultDrone => PatchPlugin.configDefaultDrone.Value;
-        public bool ConfigMox => PoolHasGems || PatchPlugin.configMox.Value;
         public bool ConfigDroneMox => PoolHasGems || PatchPlugin.configDroneMox.Value;
+        public bool ConfigMox => PoolHasGems || PatchPlugin.configMox.Value;
+        public bool ConfigDefaultDrone => PatchPlugin.configDefaultDrone.Value;
     }
 
     public static Dictionary<CardTemple, EnergyConfigInfo> ZoneConfigs = new()

--- a/docs/wiki/custom_costs.md
+++ b/docs/wiki/custom_costs.md
@@ -1,9 +1,119 @@
 ## Custom Card Costs
 ---
-The Inscryption Community Patch allows for custom card costs to be displayed in all three main acts of the game:
+In Inscryption, the player will encounter four different resources as they play: Blood, Bones, Energy, and Mox/Gems.
+These resources are needed in order to play cards with the corresponding card cost, with most cards costing at least one of these four costs.
+With the API, it's possible to create cards that cost multiple types of resources, giving modders greater creativity when creating cards.
 
-### Acts 1
-If you want to have your card display a custom card cost in either Act 1 (Leshy's Cabin), you can simply hook into one of the following events:
+There may come a time where the base costs don't meet your needs. Or maybe you just want to make a new cost.
+Regardless of reason, the API provides a few ways of creating a basic card cost using the CardCostManager.
+
+### Creating a New Cost
+To create a new card cost, you need to create a new class that inherits from the API's [CustomCardCost](InscryptionAPI.CardCosts.CustomCardCost) class.
+
+The CustomCardCost class provides you with the basic functionality to ensure your cost works.
+Note that the API does not provide support for custom cost resources, so you will need to create the logic for it yourself through patching.
+
+Once you have created your cost's class, you need to register it with the API.
+An example for all this can be found below:
+```c#
+// for simplicity, this cost replicates the logic by the energy cost
+public class MyCardCost : CustomCardCost
+{
+    // this is a required field, and should be equal to the name you pass into the API when registering your cost
+    public override string CostName => "TestCost";
+
+    // whether or not this cost's price has been satisfied by the card
+    public override bool CostSatisfied(int cardCost, PlayableCard card)
+    {
+        // if the player has enough energy to pay the cost
+	// takes the vanilla energy cost into account
+        return cardCost <= (ResourcesManager.Instance.PlayerEnergy - card.EnergyCost);
+    }
+
+    // the dialogue that's played when you try to play a card with this cost, and CostSatisfied is false
+    public override string CostUnsatisfiedHint(int cardCost, PlayableCard card)
+    {
+        return $"Eat your greens aby. {card.Info.DisplayedNameLocalized}";
+    }
+
+    // this is called after a card with this cost resolves on the board
+    // if your cost spends a resource, this is where you'd put that logic
+    public override IEnumerator OnPlayed(int cardCost, PlayableCard card)
+    {
+        // reduce the player's current energy by the card's cost
+        yield return ResourcesManager.Instance.SpendEnergy(cardCost);
+    }
+}
+
+public void AddCost()
+{
+    // when registering your card, you need to provide 2 Func's: one for grabbing the cost texture in the 3D Acts, and one for grabbing the pixel texture in Act 2
+    // if your cost is exclusive to one part of the game, you can pass in null for the appropriate Func.
+    CardCostManager.Register("api", "TestCost", typeof(TestCost), TextureMethod, PixelTextureMethod);
+}
+```
+When registering your cost, you can pass a static method for the Func's instead of creating a delegate.
+These methods MUST have 3 parameters types: int, CardInfo, PlayableCard; and return a Texture2D.
+
+The int parameter represents the card's cost, and the CardInfo and PlayableCard parameters represent the current CardInfo and PlayableCard being checked. Note that the PlayableCard parameter can be null
+
+```c#
+public static Texture2D TextureMethod(int cardCost, CardInfo info, PlayableCard card)
+{
+    return TextureHelper.GetImageAsTexture($"myCost_{cardCost}");
+}
+
+public static Texture2D PixelTextureMethod(int cardCost, CardInfo info, PlayableCard card)
+{
+    return TextureHelper.GetImageAsTexture($"myCost_pixel_{cardCost}");
+
+    // if you want the API to handle adding stack numbers, you can instead provide a 7x8 texture like so:
+    // return Part2CardCostRender.CombineIconAndCount(cardCost, TextureHelper.GetImageAsTexture("myCost_pixel_7x8"));
+}
+```
+
+Card cost textures vary based on what part of the game the cost will be displayed in.
+For Act 1, textures must be 64x28; for Act 2 they can be 30x8 or 7x8 (see above); for Act 3 there is no set size but they should be no larger than 300x78.
+
+### Adding Costs to Cards
+Custom costs are added to cards using the API's extended properties system and can be accessed the same way.
+For clarity of purpose, the API provides some extension methods for setting a CardInfo's custom cost:
+```c#
+public void AddCard()
+{
+    CardInfo info = CardManager.New("myMod", "custom_card", "Card", 1, 1);
+    info.SetCustomCost("TestCost", 1);
+
+    int cost = info.GetCustomCost("Test") // equal to 1
+}
+```
+
+### Custom Costs for Death Cards
+Death cards aren't technically cards; they're card mods that are added to a template card.
+
+Because of this, simply adding an extended property to them won't work, since properties apply to ALL copies of the card.
+If you want to create a death card that uses a custom play cost, you'll need to create a new card and then add properties to that new CardInfo.
+
+Fortunately, the API's DeathCardManager is here to handle all this.
+CreateCustomDeathCard() will return a new CardInfo that will represent your custom death card, using the data from the CardModificationInfo you give it to set the card's name, stats, etc..
+```c#
+private void AddCustomDeathCard()
+{
+    CardModificationInfo deathCardMod = new CardModificationInfo(2, 2)
+        .SetNameReplacement("Mabel").SetSingletonId("wstl_mabel")
+        .SetBonesCost(2).AddAbilities(Ability.SplitStrike)
+        .SetDeathCardPortrait(CompositeFigurine.FigurineType.SettlerWoman, 5, 2)
+        .AddCustomCostId("CustomCost", 1);
+
+    // you can then add your newly created death card to the list of default death card mods like so
+    DeathCardManager.AddDefaultDeathCard(deathCardMod);
+}
+```
+
+## Further Functionality
+In older versions of the API, adding custom costs (or their textures at least) was handled by the community patches.
+
+These methods still exist for use, and this section will go over how to use them to add cost textures the old way.
 
 ```c#
 using InscryptionCommunityPatch.Card;
@@ -17,7 +127,6 @@ Part1CardCostRender.UpdateCardCost += delegate(CardInfo card, List<Texture2D> co
 }
 ```
 
-### Act 2
 For adding custom costs to Act 2, you have two main ways of going about it:
 ```c#
 using InscryptionCommunityPatch.Card;
@@ -45,13 +154,14 @@ Part2CardCostRender.UpdateCardCost += delegate(CardInfo card, List<Texture2D> co
 }
 ```
 ### Act 3
-Custom card costs in Act 3 are a little more complex due to the fact that the Disk Card model displays card costs as 3D objects instead of texture rendered on the card art. As such, you actually have a little more control over how your custom costs are displayed if you want it.
+Card costs in Act 3 are a tad more complex since Act 3 cards display costs as 3D objects rather than simply flat textures.
 
-There are two custom cost events to hook into.
-`Part3CardCostRender.UpdateCardCostSimple` allows you to simply provide textures for your custom cost that will be rendered onto the card for you (and as you will see, there are helpers to build those textures for you as well).
-`Part3CardCostRender.UpdateCardCostComplex` gives you an opportunity to modify the `GameObject` for your card cost directly, allowing you to attach any arbitrary game objects to the card you wish.
+In practice, this means that you have more control over a cost's appearance than in other acts.
 
-The cost texture image must be 64x28 pixels for Act 1, or 30x8 pixels for Act 2.
+
+There are two custom cost events to hook into:
+`Part3CardCostRender.UpdateCardCostSimple` provides a quick way to provide/modify the cost textures that will be rendered on the card.
+`Part3CardCostRender.UpdateCardCostComplex` provides more advanced functionality, letting you modify a custom cost's `GameObject` directly, allowing you to attach any arbitrary amount of further objects/components as you wish.
 
 #### Basic Card Cost
 If you just want to display a basic card cost, all you need to do is prepare an icon that represents a single unit of your custom cost. For example, if you are building a custom cost for currency, you need an icon that represents spending one currency (for example, a `$` symbol). The width and height of the icon are up to you, but keep in mind that they will be placed onto a region that is 300x73 pixels, so the height should not exceed 73 pixels, and the wider the icon is, the fewer will fit on the space.
@@ -95,27 +205,5 @@ Part3CardCostRender.UpdateCardCostComplex += delegate(CardInfo card, List<Part3C
 {
     GameObject costObject = costs.Find(c => c.name.Equals("MyCustomCost")).CostContainer;
     // Now I can add things to the cost object directly.
-}
-```
-
-### Custom Costs for Death Cards
-Death cards aren't technically cards; they're card mods that are added to a template card.
-
-Because of this, simply adding an extended property to them won't work, since properties apply to ALL copies of the card.
-If you want to create a death card that uses a custom play cost, you'll need to create a new card and then add properties to that new CardInfo.
-
-Fortunately, the API's DeathCardManager is here to handle all this.
-CreateCustomDeathCard() will return a new CardInfo that will represent your custom death card, using the data from the CardModificationInfo you give it to set the card's name, stats, etc..
-```c#
-private void AddCustomDeathCard()
-{
-    CardModificationInfo deathCardMod = new CardModificationInfo(2, 2)
-        .SetNameReplacement("Mabel").SetSingletonId("wstl_mabel")
-        .SetBonesCost(2).AddAbilities(Ability.SplitStrike)
-        .SetDeathCardPortrait(CompositeFigurine.FigurineType.SettlerWoman, 5, 2)
-        .AddCustomCostId("CustomCost", 1);
-
-    // you can then add your newly created death card to the list of default death card mods like so
-    DeathCardManager.AddDefaultDeathCard(deathCardMod);
 }
 ```

--- a/docs/wiki/custom_properties.md
+++ b/docs/wiki/custom_properties.md
@@ -27,3 +27,8 @@ For JsonLoader users, these properties can be accessed using the same method as 
 |HideSingleStacks       |AbilityInfo    |Boolean    |If making an ability hidden should hide all of an ability's stacks or only one per.    |SetHideSingleStacks    |
 |AffectedByTidalLock    |CardInfo       |Boolean    |If the card should be killed by the effect of Tidal Lock.                              |SetAffectedByTidalLock |
 |TransformerCardId		|CardInfo		|String		|The name of the card this card will transform into when it has the Transformer sigil.  |SetTransformerCardId   |
+|RemoveGreenGem         |CardModificationInfo|Boolean    |Removes the Green Mox from the card.                                              |RemoveGreenGemCost*    |
+|RemoveOrangeGem        |CardModificationInfo|Boolean    |Removes the Green Mox from the card.                                              |RemoveOrangeGemCost*   |
+|RemoveBlueGem          |CardModificationInfo|Boolean    |Removes the Green Mox from the card.                                              |RemoveBlueGemCost*     |
+
+* You can also use RemoveGemsCost to remove multiple gems at once

--- a/docs/wiki/getting_started.md
+++ b/docs/wiki/getting_started.md
@@ -20,10 +20,14 @@ This is the recommended way to install BepInEx to the game.
 8. Run the game again. If everything runs correctly, a message will appear in the console telling you that the API was loaded.
 
 ### Installing on the Steam Deck:
-1. Download [r2modman](https://Timberborn.thunderstore.io/package/ebkr/r2modman/) on the Steam Deck’s Desktop Mode and open it from its download using its `AppImage` file
-2. Go to the setting of the profile you have for the mods and click `Browse Profile Folder`.
-3. Copy the BepInEx folder then go to Steam, and browse Inscryption's local files; paste the folder there
-4. Enter Gaming Mode and open Inscryption.  If everything was done correctly, you should see a console appear on your screen.
+1. Download [r2modman](https://Timberborn.thunderstore.io/package/ebkr/r2modman/) on the Steam Deck’s Desktop Mode and open it from its download using its `AppImage` file.
+2. Download the mods you plan on using and their dependencies..
+3. Go to the setting of the profile you are using for the mods and click `Browse Profile Folder`.
+4. Copy the BepInEx folder, then go to Steam and open Inscryption's Properties menu
+5. Go to `Installed Files` click `Browse` to open the folder containing Inscryption's local files; paste the BepInEx folder there.
+6. Enter Gaming Mode and check 'Force the use of a specific Steam Play compatibility tool' in the Properties menu under `Compatibility`.
+7. Go to the launch parameters and enter `WINEDLLOVERRIDES=“winhttp.dll=n,b” %command%`.
+8. Open Inscryption. If everything was done correctly, you should see a console appear on your screen.
 
 ## Getting Started: Modding
 ---
@@ -78,10 +82,10 @@ Otherwise, continue reading this wiki.
 ### Modding Resources
 [Inscryption Modding Discord](https://discord.gg/QrJEF5Denm)
 
-[Vanilla and Modded Enumerations](https://github.com/SaxbyMod/SabyModEnums)
-
 [BepInEx documentation](https://docs.bepinex.dev/)
 
 [Harmony patching article](https://harmony.pardeike.net/articles/patching.html)
 
 [Example Mod using C#](https://github.com/debugman18/InscryptionExampleMod)
+
+[Vanilla and Modded Enumerations](https://github.com/SaxbyMod/SabyModEnums)


### PR DESCRIPTION
- Fixed merged and totem sigils being uninteractable if the icon has been flipped vertically
- Fixed pixel Shapeshifter patch not correctly patching DisguiseOutOfBattle
- Fixed temporary decal mods not being removed in Act 1
- Fixed softlock in Part 1 during the boon-gaining sequence
- Fixed all copies of a custom challenge becoming activated/deactivated when the page is reloaded
- Fixed Sentry ability softlocking when the base card dies before all Sentry stacks are triggered
- Fixed softlock when talking card dialogue cannot be parsed in certain conditions
- Added public method GetIjiraqDisguises to pixel Shapeshifter patch for easier modification of Shapeshifter for modders
- Added variant of PeltManager.New
- Added variant of PlayableCard.AllAbilities that accounts for negated abilities in TemporaryMods
- Added support for creating custom card costs using new class CustomCardCost; see wiki for more information
- Added ability to remove gems costs from a card using CardModificationInfos
- Added a number of extension methods for CardModificationInfos (RemoveGemsCost, SetCustomCostId, etc)
- Added helpers for getting TextBox.Style from CardInfo.temple or the chosen ambition
- Rewrote CardModificationInfoManager's id system for setting persistent extended properties in a CardModificationInfo's singletonId
- Rewrote pixel Shapeshifter patch to RevealInBattle to hopefully prevent errors in Act 1
- PeltManager.New now throws an error when getCardChoices is null
- Changed LogLevel of dialogue event insertion message from Info to Debug
- API death cards now use the clean singleton id when creating the death card info mod
- Temporary decal mods are now removed from Act 2 cards instead of being cleared
- Opponent snipers will now target a random slot if there are no opposing cards (previously only targeted the opposing slot)