### PR TITLE
Add text redirect support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,24 @@
 <details>
 <summary>View Changelog</summary>
 
+# 2.22.0
+- Added AllFullBoons list to BoonManager
+- Added FullConsumableItemData to ConsumableItemManager
+- Added FullBoon objects for each vanilla Boon
+- Added RuleBookManager.GetUnformattedPageId for retrieving a pageId without the API identifier
+- Added support for rulebook text redirects
+- Added GetFullBoon and GetFullConsumableItemData extension methods
+- Added support for boons and items appearing in multiple acts' rulebooks
+- Added metaCategories field to FullBoon
+- Added BoonShouldBeAdded method to BoonManager
+- Added ItemShouldBeAdded method to ConsumableItemPatches
+- Fixed RuleBook construction patches having lower patch priority than intended
+- Moved ConsumableItemManager patches to ConsumableItemPatches class
+- Changed patch to LoadPage from a prefix to a transpiler to avoid mod conflicts
+    - modders can modify this transpiler by overriding 
+- Tweaked how custom rulebook pages are added and detected
+- Tweaked wiki page for adding custom rulebook sections, added additional section on text redirects
+
 # 2.21.1
 - Fixed RuleBookManager not syncing when playing with no custom rulebook sections
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,10 +12,13 @@
 - Added ModificationType.SetSharedRulebook - used for slot modifications that should share their rulebook entry with other slot modifications
 - Added support for multiple rulebook sprites for slot modifications (SetRulebookP03Sprite, SetRulebookGrimoraSprite, SetRulebookMagnificusSprite)
 - Added RuleBookController.Instance.OpenToCustomPage
+- Added CustomDiskTalkingCard abstract class
+- Added TalkingCardManager.NewDisk and TalkingCardManager.CreateDisk
 - Fixed RuleBook construction patches having lower patch priority than intended
 - Fixed slot modification interactable being enabled when no rulebook entry exists
 - Fixed slot modification rulebook pages not working in Act 3
 - Fixed rulebook sprites being smaller than normal after flipping to a slot modification rulebook page
+- Fixed DiskTalkingCards created through the API not correctly working under certain conditions
 - Moved ConsumableItemManager patches to a separate ConsumableItemPatches class
 - Modified implementation of rulebook fill page logic to let modders patch the API logic
     - Patch 'RuleBookManagerPatches.FillPage' to do this

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,22 +2,20 @@
 <summary>View Changelog</summary>
 
 # 2.22.0
-- Added AllFullBoons list to BoonManager
-- Added FullConsumableItemData to ConsumableItemManager
 - Added FullBoon objects for each vanilla Boon
-- Added RuleBookManager.GetUnformattedPageId for retrieving a pageId without the API identifier
-- Added support for rulebook text redirects
-- Added GetFullBoon and GetFullConsumableItemData extension methods
+- Added 'AllFullBoons' list to BoonManager
 - Added support for boons and items appearing in multiple acts' rulebooks
-- Added metaCategories field to FullBoon
-- Added BoonShouldBeAdded method to BoonManager
-- Added ItemShouldBeAdded method to ConsumableItemPatches
+- Added RuleBookRedirectManager and support for rulebook text redirects/page links
+- Added additional methods to RuleBookManager: ItemShouldBeAdded, BoonShouldBeAdded, SlotModShouldBeAdded, GetUnformattedPageId
+- Added GetFullBoon and GetFullConsumableItemData extension methods
+- Added extension methods for adding text redirects to abilities, stat icons, items, boons, slot modifications, and rulebook pages
 - Fixed RuleBook construction patches having lower patch priority than intended
-- Moved ConsumableItemManager patches to ConsumableItemPatches class
-- Changed patch to LoadPage from a prefix to a transpiler to avoid mod conflicts
-    - modders can modify this transpiler by overriding 
+- Moved ConsumableItemManager patches to a separate ConsumableItemPatches class
+- Modified implementation of rulebook fill page logic to let modders patch the API logic
+    - Patch 'RuleBookManagerPatches.FillPage' to do this
 - Tweaked how custom rulebook pages are added and detected
-- Tweaked wiki page for adding custom rulebook sections, added additional section on text redirects
+- Tweaked wiki page for adding custom rulebook sections
+- Added wiki section on adding text redirects
 
 # 2.21.1
 - Fixed RuleBookManager not syncing when playing with no custom rulebook sections

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,13 +9,19 @@
 - Added additional methods to RuleBookManager: ItemShouldBeAdded, BoonShouldBeAdded, SlotModShouldBeAdded, GetUnformattedPageId
 - Added GetFullBoon and GetFullConsumableItemData extension methods
 - Added extension methods for adding text redirects to abilities, stat icons, items, boons, slot modifications, and rulebook pages
+- Added ModificationType.SetSharedRulebook - used for slot modifications that should share their rulebook entry with other slot modifications
+- Added support for multiple rulebook sprites for slot modifications (SetRulebookP03Sprite, SetRulebookGrimoraSprite, SetRulebookMagnificusSprite)
+- Added RuleBookController.Instance.OpenToCustomPage
 - Fixed RuleBook construction patches having lower patch priority than intended
+- Fixed slot modification interactable being enabled when no rulebook entry exists
+- Fixed slot modification rulebook pages not working in Act 3
+- Fixed rulebook sprites being smaller than normal after flipping to a slot modification rulebook page
 - Moved ConsumableItemManager patches to a separate ConsumableItemPatches class
 - Modified implementation of rulebook fill page logic to let modders patch the API logic
     - Patch 'RuleBookManagerPatches.FillPage' to do this
 - Tweaked how custom rulebook pages are added and detected
-- Tweaked wiki page for adding custom rulebook sections
-- Added wiki section on adding text redirects
+- Wiki: Tweaked page for adding custom rulebook sections
+- Wiki: Added section on adding text redirects
 
 # 2.21.1
 - Fixed RuleBookManager not syncing when playing with no custom rulebook sections

--- a/InscryptionAPI/Ascension/AscensionScreenManager.cs
+++ b/InscryptionAPI/Ascension/AscensionScreenManager.cs
@@ -8,7 +8,7 @@ namespace InscryptionAPI.Ascension;
 [HarmonyPatch]
 public static class AscensionScreenManager
 {
-    internal static List<Type> registeredScreens = new List<Type>();
+    internal static List<Type> registeredScreens = new();
 
     internal static Dictionary<AscensionMenuScreens.Screen, AscensionRunSetupScreenBase> screens;
 

--- a/InscryptionAPI/Boons/BoonManager.cs
+++ b/InscryptionAPI/Boons/BoonManager.cs
@@ -342,7 +342,7 @@ public static class BoonManager
             {
                 int insertPosition = __result.FindLastIndex(rbi => rbi.pagePrefab == pageRangeInfo.rangePrefab) + 1;
                 int curPageNum = (int)BoonData.Type.NUM_TYPES;
-                List<FullBoon> abilitiesToAdd = NewBoons.Where(x => BoonShouldBeAdded(x, metaCategory)).ToList();
+                List<FullBoon> abilitiesToAdd = NewBoons.Where(x => RuleBookManager.BoonShouldBeAdded(x, metaCategory)).ToList();
                 //InscryptionAPIPlugin.Logger.LogInfo($"Adding {abilitiesToAdd.Count} out of {NewAbilities.Count} abilities to rulebook");
                 foreach (FullBoon fboo in abilitiesToAdd)
                 {
@@ -356,10 +356,5 @@ public static class BoonManager
                 }
             }
         }
-    }
-
-    public static bool BoonShouldBeAdded(FullBoon fullBoon, AbilityMetaCategory metaCategory)
-    {
-        return fullBoon?.boon?.icon != null && fullBoon.appearInRulebook && fullBoon.metaCategories.Contains(metaCategory);
     }
 }

--- a/InscryptionAPI/Boons/BoonManager.cs
+++ b/InscryptionAPI/Boons/BoonManager.cs
@@ -2,6 +2,7 @@ using DiskCardGame;
 using HarmonyLib;
 using InscryptionAPI.Guid;
 using InscryptionAPI.Helpers;
+using InscryptionAPI.RuleBook;
 using System.Collections;
 using System.Collections.ObjectModel;
 using UnityEngine;
@@ -38,14 +39,34 @@ public static class BoonManager
         /// Indicates if the player can have multiple instances of this boon in their deck.
         /// </summary>
         public bool stacks;
+
+        public List<AbilityMetaCategory> metaCategories = new();
+
+        /// <summary>
+        /// Tracks all rulebook redirects that this ability's description will have. Explanation of the variables is as follows:
+        /// Key (string): the text that will be recoloured to indicate that it's clickable.
+        /// Tuple.Item1 (PageRangeType): the type of page the redirect will go to. Use PageRangeType.Unique if you want to redirect to a custom rulebook page using its pageId.
+        /// Tuple.Item2 (Color): the colour the Key text will be recoloured to.
+        /// Tuple.Item3 (string): the id that the API will match against to find the redirect page. Eg, for ability redirects this will be the Ability id as a string.
+        /// </summary>
+        public Dictionary<string, RuleBookManager.RedirectInfo> RulebookDescriptionRedirects = new();
     }
 
     /// <summary>
     /// All boons that come as part of the vanilla game.
     /// </summary>
     public static readonly ReadOnlyCollection<BoonData> BaseGameBoons = new(Resources.LoadAll<BoonData>("Data/Boons"));
-
+    public static readonly List<FullBoon> FullBaseGameBoons = BaseGameBoons.Select(x => new FullBoon()
+    {
+        appearInRulebook = true,
+        boon = x,
+        stacks = x.type == BoonData.Type.MinorStartingBones,
+        boonHandlerType = null, // vanilla Boons are hard-coded into the game, so no custom behaviour Type
+        metaCategories = new() { AbilityMetaCategory.Part1Rulebook } // vanilla boons appear in Act 1, obviously
+    }).ToList();
     internal static readonly ObservableCollection<FullBoon> NewBoons = new();
+
+    public static List<FullBoon> AllFullBoons { get; private set; } = new(FullBaseGameBoons);
 
     /// <summary>
     /// All boons, including vanilla and mod-added boons.
@@ -142,10 +163,28 @@ public static class BoonManager
         return New<T>(guid, name, rulebookDescription, pathToIcon, pathToCardArt, stackable, appearInLeshyTrials, appearInRulebook);
     }
 
+    public static BoonData.Type AddRuleBookCategories(this BoonData.Type boonType, params AbilityMetaCategory[] categories)
+    {
+        FullBoon boon = boonType.GetFullBoon();
+        if (boon != null)
+        {
+            foreach (AbilityMetaCategory category in categories)
+            {
+                if (!boon.metaCategories.Contains(category))
+                    boon.metaCategories.Add(category);
+            }
+        }
+        return boonType;
+    }
+    public static FullBoon GetFullBoon(this BoonData.Type boonType)
+    {
+        return AllFullBoons.Find(x => x.boon.type == boonType);
+    }
+
     internal static void SyncBoonList()
     {
-        var boons = BaseGameBoons.Concat(NewBoons.Select((x) => x.boon)).ToList();
-        AllBoonsCopy = boons;
+        AllBoonsCopy = BaseGameBoons.Concat(NewBoons.Select(x => x.boon)).ToList();
+        AllFullBoons = FullBaseGameBoons.Concat(NewBoons).ToList();
     }
 
     static BoonManager()
@@ -168,32 +207,32 @@ public static class BoonManager
     private static IEnumerator ActivatePreCombatBoons(IEnumerator result, BoonsHandler __instance)
     {
         BoonBehaviour.DestroyAllInstances();
-        if (__instance.BoonsEnabled && RunState.Run != null && RunState.Run.playerDeck != null && RunState.Run.playerDeck.Boons != null && NewBoons != null)
+
+        if (__instance.BoonsEnabled && RunState.Run?.playerDeck != null && RunState.Run.playerDeck.Boons != null && NewBoons != null)
         {
             foreach (BoonData boon in RunState.Run.playerDeck.Boons)
             {
-                if (boon != null)
+                if (boon == null)
+                    continue;
+
+                FullBoon nb = AllFullBoons.Find(x => x.boon.type == boon.type);
+                if (nb == null)
+                    continue;
+
+                int instances = BoonBehaviour.CountInstancesOfType(nb.boon.type);
+                if (nb != null && nb.boonHandlerType != null && nb.boonHandlerType.IsSubclassOf(typeof(BoonBehaviour)) && (nb.stacks || instances < 1))
                 {
-                    FullBoon nb = NewBoons.ToList().Find((x) => x.boon.type == boon.type);
-
-                    if (nb == null)
-                        continue;
-
-                    int instances = BoonBehaviour.CountInstancesOfType(nb.boon.type);
-                    if (nb != null && nb.boonHandlerType != null && nb.boonHandlerType.IsSubclassOf(typeof(BoonBehaviour)) && (nb.stacks || instances < 1))
+                    GameObject boonhandler = new(nb.boon.name + " Boon Handler");
+                    BoonBehaviour behav = boonhandler.AddComponent(nb.boonHandlerType) as BoonBehaviour;
+                    if (behav != null)
                     {
-                        GameObject boonhandler = new(nb.boon.name + " Boon Handler");
-                        BoonBehaviour behav = boonhandler.AddComponent(nb.boonHandlerType) as BoonBehaviour;
-                        if (behav != null)
+                        GlobalTriggerHandler.Instance?.RegisterNonCardReceiver(behav);
+                        behav.boon = nb;
+                        behav.instanceNumber = instances + 1;
+                        BoonBehaviour.Instances.Add(behav);
+                        if (behav.RespondsToPreBoonActivation())
                         {
-                            GlobalTriggerHandler.Instance?.RegisterNonCardReceiver(behav);
-                            behav.boon = nb;
-                            behav.instanceNumber = instances + 1;
-                            BoonBehaviour.Instances.Add(behav);
-                            if (behav.RespondsToPreBoonActivation())
-                            {
-                                yield return behav.OnPreBoonActivation();
-                            }
+                            yield return behav.OnPreBoonActivation();
                         }
                     }
                 }
@@ -242,7 +281,7 @@ public static class BoonManager
     {
         if (TurnManager.Instance != null && !TurnManager.Instance.GameEnded && !TurnManager.Instance.GameEnding && !TurnManager.Instance.IsSetupPhase && TurnManager.Instance.Opponent != null)
         {
-            FullBoon nb = NewBoons.ToList().Find((x) => x.boon.type == boonType);
+            FullBoon nb = NewBoons.ToList().Find(x => x.boon.type == boonType);
             if (nb != null && nb.boonHandlerType != null && (nb.stacks || BoonBehaviour.CountInstancesOfType(nb.boon.type) < 1))
             {
                 int instances = BoonBehaviour.CountInstancesOfType(nb.boon.type);
@@ -287,35 +326,40 @@ public static class BoonManager
     [HarmonyPostfix]
     private static void LoadBoons(DeckInfo __instance)
     {
-        __instance.boons.RemoveAll((x) => x == null);
+        __instance.boons.RemoveAll(x => x == null);
     }
 
     [HarmonyPatch(typeof(RuleBookInfo), nameof(RuleBookInfo.ConstructPageData))]
-    [HarmonyPostfix, HarmonyPriority(100)]
+    [HarmonyPostfix]
     private static void ConstructPageData(ref List<RuleBookPageInfo> __result, RuleBookInfo __instance, AbilityMetaCategory metaCategory)
     {
-        if (NewBoons.Count > 0 && metaCategory == AbilityMetaCategory.Part1Rulebook)
+        if (NewBoons.Count == 0)
+            return;
+
+        foreach (PageRangeInfo pageRangeInfo in __instance.pageRanges)
         {
-            foreach (PageRangeInfo pageRangeInfo in __instance.pageRanges)
+            if (pageRangeInfo.type == PageRangeType.Boons)
             {
-                if (pageRangeInfo.type == PageRangeType.Boons)
+                int insertPosition = __result.FindLastIndex(rbi => rbi.pagePrefab == pageRangeInfo.rangePrefab) + 1;
+                int curPageNum = (int)BoonData.Type.NUM_TYPES;
+                List<FullBoon> abilitiesToAdd = NewBoons.Where(x => BoonShouldBeAdded(x, metaCategory)).ToList();
+                //InscryptionAPIPlugin.Logger.LogInfo($"Adding {abilitiesToAdd.Count} out of {NewAbilities.Count} abilities to rulebook");
+                foreach (FullBoon fboo in abilitiesToAdd)
                 {
-                    int insertPosition = __result.FindLastIndex(rbi => rbi.pagePrefab == pageRangeInfo.rangePrefab) + 1;
-                    int curPageNum = (int)Ability.NUM_ABILITIES;
-                    List<FullBoon> abilitiesToAdd = NewBoons.Where(x => x?.boon != null && BoonsUtil.GetData(x.boon.type)?.icon != null).ToList();
-                    //InscryptionAPIPlugin.Logger.LogInfo($"Adding {abilitiesToAdd.Count} out of {NewAbilities.Count} abilities to rulebook");
-                    foreach (FullBoon fboo in abilitiesToAdd)
-                    {
-                        RuleBookPageInfo info = new();
-                        info.pagePrefab = pageRangeInfo.rangePrefab;
-                        info.headerText = string.Format(Localization.Translate("APPENDIX XII, SUBSECTION I - MOD BOONS {0}"), curPageNum);
-                        __instance.FillBoonPage(info, pageRangeInfo, (int)fboo.boon.type);
-                        __result.Insert(insertPosition, info);
-                        curPageNum += 1;
-                        insertPosition += 1;
-                    }
+                    RuleBookPageInfo info = new();
+                    info.pagePrefab = pageRangeInfo.rangePrefab;
+                    info.headerText = string.Format(Localization.Translate("APPENDIX XII, SUBSECTION I - MOD BOONS {0}"), curPageNum);
+                    __instance.FillBoonPage(info, pageRangeInfo, (int)fboo.boon.type);
+                    __result.Insert(insertPosition, info);
+                    curPageNum += 1;
+                    insertPosition += 1;
                 }
             }
         }
+    }
+
+    public static bool BoonShouldBeAdded(FullBoon fullBoon, AbilityMetaCategory metaCategory)
+    {
+        return fullBoon?.boon?.icon != null && fullBoon.appearInRulebook && fullBoon.metaCategories.Contains(metaCategory);
     }
 }

--- a/InscryptionAPI/Card/SpecialStatIconManager.cs
+++ b/InscryptionAPI/Card/SpecialStatIconManager.cs
@@ -1,6 +1,7 @@
 using DiskCardGame;
 using HarmonyLib;
 using InscryptionAPI.Guid;
+using InscryptionAPI.RuleBook;
 using System.Collections.ObjectModel;
 using UnityEngine;
 
@@ -26,6 +27,15 @@ public static class StatIconManager
         public readonly SpecialTriggeredAbility AbilityId;
         public readonly StatIconInfo Info;
         public readonly Type VariableStatBehavior;
+
+        /// <summary>
+        /// Tracks all rulebook redirects that this ability's description will have. Explanation of the variables is as follows:
+        /// Key (string): the text that will be recoloured to indicate that it's clickable.
+        /// Tuple.Item1 (PageRangeType): the type of page the redirect will go to. Use PageRangeType.Unique if you want to redirect to a custom rulebook page using its pageId.
+        /// Tuple.Item2 (Color): the colour the Key text will be recoloured to.
+        /// Tuple.Item3 (string): the id that the API will match against to find the redirect page. Eg, for ability redirects this will be the Ability id as a string.
+        /// </summary>
+        public Dictionary<string, RuleBookManager.RedirectInfo> RulebookDescriptionRedirects = new();
 
         public FullStatIcon(SpecialStatIcon id, SpecialTriggeredAbility abilityId, StatIconInfo info, Type variableStatBehavior)
         {
@@ -116,8 +126,8 @@ public static class StatIconManager
     }
 
     [HarmonyPatch(typeof(RuleBookInfo), "ConstructPageData", new Type[] { typeof(AbilityMetaCategory) })]
-    [HarmonyPostfix, HarmonyPriority(100)]
-    private static void FixRulebook(AbilityMetaCategory metaCategory, RuleBookInfo __instance, ref List<RuleBookPageInfo> __result)
+    [HarmonyPostfix]
+    private static void AddNewStatIconsToRuleBook(AbilityMetaCategory metaCategory, RuleBookInfo __instance, ref List<RuleBookPageInfo> __result)
     {
         if (NewStatIcons.Count > 0)
         {

--- a/InscryptionAPI/InscryptionAPI.csproj
+++ b/InscryptionAPI/InscryptionAPI.csproj
@@ -10,7 +10,7 @@
         <DebugType>full</DebugType>
         <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
         <EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>
-        <Version>2.21.1</Version>
+        <Version>2.22.0</Version>
     </PropertyGroup>
 
     <PropertyGroup>

--- a/InscryptionAPI/InscryptionAPIPlugin.cs
+++ b/InscryptionAPI/InscryptionAPIPlugin.cs
@@ -30,7 +30,7 @@ public class InscryptionAPIPlugin : BaseUnityPlugin
 {
     public const string ModGUID = "cyantist.inscryption.api";
     public const string ModName = "InscryptionAPI";
-    public const string ModVer = "2.21.1";
+    public const string ModVer = "2.22.0";
 
     public static string Directory = "";
 

--- a/InscryptionAPI/Items/ConsumableItemDataExtensions.cs
+++ b/InscryptionAPI/Items/ConsumableItemDataExtensions.cs
@@ -1,4 +1,4 @@
-﻿using DiskCardGame;
+using DiskCardGame;
 using System.Runtime.CompilerServices;
 using UnityEngine;
 
@@ -34,7 +34,35 @@ public static class ConsumableItemDataExtensions
         data.rulebookCategory = rulebookCategory;
         return data;
     }
+    public static ConsumableItemData AddExtraRulebookCategories(this ConsumableItemData data, params AbilityMetaCategory[] rulebookCategories)
+    {
+        ConsumableItemManager.FullConsumableItemData fullItem = data.GetFullConsumableItemData();
+        if (fullItem != null)
+        {
+            foreach (AbilityMetaCategory abilityMetaCategory in rulebookCategories)
+            {
+                if (!fullItem.rulebookMetaCategories.Contains(abilityMetaCategory))
+                    fullItem.rulebookMetaCategories.Add(abilityMetaCategory);
+            }
+        }
+        return data;
+    }
 
+    /// <summary>
+    /// Retrieves the FullConsumableItemData associated with the given ConsumableItemData.
+    /// </summary>
+    /// <param name="data">The ConsumableItemData we want to find the FullConsumableItemData of.</param>
+    /// <param name="fallBackToName">If the initial retrieval returns null and this is true, search again for the FullConsumableItemData using the data's mod prefix and rulebookName.</param>
+    /// <returns>The FullConsumableItemData associated with the given COnsumableItemData, or null if it does not exist.</returns>
+    public static ConsumableItemManager.FullConsumableItemData GetFullConsumableItemData(this ConsumableItemData data, bool fallBackToName = true)
+    {
+        ConsumableItemManager.FullConsumableItemData fullItem = ConsumableItemManager.allFullItemDatas.Find(x => x.itemData == data);
+
+        if (fullItem == null && fallBackToName)
+            fullItem = ConsumableItemManager.allFullItemDatas.Find(x => x.itemData.GetModPrefix() == data.GetModPrefix() && x.itemData.rulebookName == data.rulebookName);
+
+        return fullItem;
+    }
     /// <returns>The same ConsumableItemData so a chain can continue.</returns>
     public static ConsumableItemData SetRulebookName(this ConsumableItemData data, string rulebookName)
     {

--- a/InscryptionAPI/Items/ConsumableItemPatches.cs
+++ b/InscryptionAPI/Items/ConsumableItemPatches.cs
@@ -3,6 +3,7 @@ using HarmonyLib;
 using InscryptionAPI.Boons;
 using InscryptionAPI.Helpers;
 using InscryptionAPI.Items.Extensions;
+using InscryptionAPI.RuleBook;
 using System;
 using System.Collections;
 using System.Collections.Generic;
@@ -201,14 +202,9 @@ public static class ConsumableItemPatches
     {
         List<ConsumableItemData> allConsumables = ItemsUtil.AllConsumables;
         return instance.ConstructPages(pageRange, allConsumables.Count, 0,
-            (int index) => ItemShouldBeAdded(allConsumables[index], metaCategory),
+            (int index) => RuleBookManager.ItemShouldBeAdded(allConsumables[index], metaCategory),
             instance.FillItemPage,
             Localization.Translate("APPENDIX XII, SUBSECTION IX - ITEMS {0}")
         );
-    }
-
-    public static bool ItemShouldBeAdded(ConsumableItemData item, AbilityMetaCategory metaCategory)
-    {
-        return item.rulebookCategory == metaCategory || item.GetFullConsumableItemData()?.rulebookMetaCategories.Contains(metaCategory) == true;
     }
 }

--- a/InscryptionAPI/Items/ConsumableItemPatches.cs
+++ b/InscryptionAPI/Items/ConsumableItemPatches.cs
@@ -1,0 +1,214 @@
+using DiskCardGame;
+using HarmonyLib;
+using InscryptionAPI.Boons;
+using InscryptionAPI.Helpers;
+using InscryptionAPI.Items.Extensions;
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Reflection;
+using System.Reflection.Emit;
+using System.Text;
+using UnityEngine;
+using static InscryptionAPI.Items.ConsumableItemManager;
+
+namespace InscryptionAPI.Items;
+
+[HarmonyPatch]
+public static class ConsumableItemPatches
+{
+    [HarmonyPostfix, HarmonyPatch(typeof(ResourceBank), "Awake", new System.Type[] { })]
+    private static void ResourceBank_Awake(ResourceBank __instance)
+    {
+        Initialize();
+    }
+
+    [HarmonyPostfix, HarmonyPatch(typeof(ItemsUtil), "AllConsumables", MethodType.Getter)]
+    private static void ItemsUtil_AllConsumables(ref List<ConsumableItemData> __result)
+    {
+        __result.AddRange(allNewItems);
+    }
+
+    [HarmonyPrefix, HarmonyPatch(typeof(ConsumableItem), nameof(ConsumableItem.CanActivate), new Type[] { })]
+    private static bool ConsumableItem_CanActivate(ConsumableItem __instance, ref bool __result)
+    {
+        if (__instance.Data is ConsumableItemData consumableItemData && consumableItemData.CanActivateOutsideBattles() && !GameFlowManager.IsCardBattle)
+        {
+            // We are not in a card battle. Unique behaviour!
+            __result = __instance.ExtraActivationPrerequisitesMet();
+            return false;
+        }
+
+        return true; // Keep original activation behaviour
+    }
+
+    [HarmonyPostfix, HarmonyPatch(typeof(ConsumableItemSlot), "ConsumeItem")]
+    private static IEnumerator ConsumableItemSlot_ConsumeItemEnumerator(IEnumerator result, ConsumableItemSlot __instance)
+    {
+        ConsumableItemSlot_ConsumeItem.currentItemData = __instance.Consumable.Data;
+        return result;
+    }
+
+    [HarmonyPrefix, HarmonyPatch(typeof(ItemSlot), "CreateItem", new Type[] { typeof(ItemData), typeof(bool) })]
+    private static bool ItemSlot_CreateItem(ItemSlot __instance, ItemData data, bool skipDropAnimation)
+    {
+        if (__instance.Item != null)
+        {
+            UnityObject.Destroy(__instance.Item.gameObject);
+        }
+
+        string prefabId = "Prefabs/Items/" + data.PrefabId;
+        GameObject gameObject = null;
+        if (prefabIDToResourceLookup.TryGetValue(prefabId.ToLowerInvariant(), out ConsumableItemResource resource) && data is ConsumableItemData consumableItemData)
+        {
+            GameObject prefab = resource.Get<GameObject>();
+            if (prefab == null)
+            {
+                InscryptionAPIPlugin.Logger.LogError($"Failed to get {consumableItemData.rulebookName} model from ConsumableItemAssetGetter " + resource);
+            }
+            else
+            {
+                gameObject = UnityObject.Instantiate<GameObject>(prefab, __instance.transform);
+            }
+
+            resource.PreSetupCallback?.Invoke(gameObject, consumableItemData);
+            SetupPrefab(consumableItemData, gameObject, consumableItemData.GetComponentType(), consumableItemData.GetPrefabModelType());
+        }
+        else
+        {
+            gameObject = UnityObject.Instantiate<GameObject>(ResourceBank.Get<GameObject>(prefabId), __instance.transform);
+            if (gameObject == null)
+            {
+                InscryptionAPIPlugin.Logger.LogError($"Failed to get {data.name} model from ResourceBank " + prefabId);
+            }
+        }
+
+        if (!gameObject.activeSelf)
+        {
+            gameObject.SetActive(true);
+        }
+
+        gameObject.transform.localPosition = Vector3.zero;
+        __instance.Item = gameObject.GetComponent<Item>();
+        __instance.Item.SetData(data);
+        if (skipDropAnimation)
+        {
+            __instance.Item.PlayEnterAnimation(true);
+        }
+
+        // Setup cards
+        if (__instance.Item is CardBottleItem cardBottleItem && data is ConsumableItemData consumableItemData2)
+        {
+            string cardWithinBottle = consumableItemData2.GetCardWithinBottle();
+            if (!string.IsNullOrEmpty(cardWithinBottle))
+            {
+                CardInfo cardInfo = CardLoader.GetCardByName(cardWithinBottle);
+                if (cardInfo != null)
+                {
+                    cardBottleItem.cardInfo = cardInfo;
+                    cardBottleItem.GetComponentInChildren<SelectableCard>().SetInfo(cardInfo);
+                    cardBottleItem.gameObject.GetComponent<AssignCardOnStart>().enabled = false;
+                }
+                else
+                {
+                    InscryptionAPIPlugin.Logger.LogError("Could not get card for bottled card item: " + cardWithinBottle);
+                }
+            }
+        }
+
+        return false;
+    }
+
+    [HarmonyPatch]
+    internal class ConsumableItemSlot_ConsumeItem
+    {
+        private static Type ConsumableItemSlot_ConsumeItem_Class = Type.GetType("DiskCardGame.ConsumableItemSlot+<ConsumeItem>d__15, Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null");
+
+        private static MethodInfo SwitchToViewMethod = AccessTools.Method(typeof(ViewManager), nameof(ViewManager.SwitchToView), new Type[] { typeof(View), typeof(bool), typeof(bool) });
+        private static MethodInfo CustomSwitchToViewMethod = AccessTools.Method(typeof(ConsumableItemSlot_ConsumeItem), nameof(SwitchToView), new Type[] { typeof(ViewManager), typeof(View), typeof(bool), typeof(bool) });
+
+        internal static ItemData currentItemData = null;
+
+        public static IEnumerable<MethodBase> TargetMethods()
+        {
+            yield return AccessTools.Method(ConsumableItemSlot_ConsumeItem_Class, "MoveNext");
+        }
+
+        public static IEnumerable<CodeInstruction> Transpiler(IEnumerable<CodeInstruction> instructions)
+        {
+            // === We want to turn this
+
+            // ConsumableItemSlot consumableItemSlot = <>4__this;
+            // ...
+            // Singleton<ViewManager>.Instance.SwitchToView(..., ..., ...);
+
+            // === Into this
+
+            // ConsumableItemSlot consumableItemSlot = <>4__this;
+            // ...
+            // GetNextTargetView(..., ..., ...);
+
+            // ===
+
+            List<CodeInstruction> codes = new(instructions);
+            for (int i = 0; i < codes.Count; i++)
+            {
+                CodeInstruction codeInstruction = codes[i];
+                if (codeInstruction.operand == SwitchToViewMethod)
+                {
+                    codeInstruction.operand = CustomSwitchToViewMethod; // Call CustomSwitchToView instead of View
+                    i++;
+                }
+            }
+
+            return codes;
+        }
+
+        public static void SwitchToView(ViewManager instance, View view, bool immediate, bool lockAfter)
+        {
+            if (currentItemData != null && currentItemData is ConsumableItemData itemData && itemData.CanActivateOutsideBattles())
+            {
+                return; // Do nothing!
+            }
+
+            instance.SwitchToView(view, immediate, lockAfter);
+        }
+    }
+
+    [HarmonyTranspiler, HarmonyPatch(typeof(RuleBookInfo), nameof(RuleBookInfo.ConstructPageData))]
+    private static IEnumerable<CodeInstruction> ConstructItemPageData(IEnumerable<CodeInstruction> instructions)
+    {
+        List<CodeInstruction> codes = new(instructions);
+
+        int startIndex = codes.FindIndex(x => x.opcode == OpCodes.Ldfld && x.operand.ToString() == "System.Collections.Generic.List`1[DiskCardGame.ConsumableItemData] allConsumables");
+        if (startIndex != -1)
+        {
+            startIndex -= 3;
+            int endIndex = codes.FindIndex(startIndex, x => x.opcode == OpCodes.Callvirt && x.operand.ToString() == "System.Collections.Generic.List`1[DiskCardGame.RuleBookPageInfo] ConstructPages(DiskCardGame.PageRangeInfo, Int32, Int32, System.Func`2[System.Int32,System.Boolean], System.Action`3[DiskCardGame.RuleBookPageInfo,DiskCardGame.PageRangeInfo,System.Int32], System.String)");
+            MethodInfo method = AccessTools.Method(typeof(ConsumableItemPatches), nameof(ConsumableItemPatches.ConstructItemPages), new Type[]
+            { typeof(RuleBookInfo), typeof(PageRangeInfo), typeof(AbilityMetaCategory) });
+
+            codes.RemoveRange(startIndex, endIndex - startIndex + 1);
+            codes.Insert(startIndex++, new(OpCodes.Ldarg_0));
+            codes.Insert(startIndex++, new(OpCodes.Ldloc_3));
+            codes.Insert(startIndex++, new(OpCodes.Ldarg_1));
+            codes.Insert(startIndex++, new(OpCodes.Callvirt, method));
+        }
+        return codes;
+    }
+
+    public static List<RuleBookPageInfo> ConstructItemPages(RuleBookInfo instance, PageRangeInfo pageRange, AbilityMetaCategory metaCategory)
+    {
+        List<ConsumableItemData> allConsumables = ItemsUtil.AllConsumables;
+        return instance.ConstructPages(pageRange, allConsumables.Count, 0,
+            (int index) => ItemShouldBeAdded(allConsumables[index], metaCategory),
+            instance.FillItemPage,
+            Localization.Translate("APPENDIX XII, SUBSECTION IX - ITEMS {0}")
+        );
+    }
+
+    public static bool ItemShouldBeAdded(ConsumableItemData item, AbilityMetaCategory metaCategory)
+    {
+        return item.rulebookCategory == metaCategory || item.GetFullConsumableItemData()?.rulebookMetaCategories.Contains(metaCategory) == true;
+    }
+}

--- a/InscryptionAPI/Rulebook/PageTextInteractable.cs
+++ b/InscryptionAPI/Rulebook/PageTextInteractable.cs
@@ -1,0 +1,64 @@
+using DiskCardGame;
+using InscryptionAPI.Card;
+using InscryptionAPI.Nodes;
+using System;
+using System.Collections.Generic;
+using System.Text;
+using UnityEngine;
+
+namespace InscryptionAPI.RuleBook;
+
+public class PageTextInteractable : AlternateInputInteractable
+{
+    public override CursorType CursorType => CursorType.Inspect;
+
+    public PageRangeType redirectType;
+    public string redirectId;
+
+    /*public Vector3 relativeToRulebookPosition;
+    public override void ManagedLateUpdate()
+    {
+        base.ManagedLateUpdate();
+        // cx, cy - center of square coordinates
+        // x, y - coordinates of a corner point of the square
+        // theta is the angle of rotation
+
+        // translate point to origin
+        float cx = RuleBookRedirectManager.Instance.currentPageLengths[0] / 2f;
+        float cy = RuleBookRedirectManager.Instance.currentPageLengths[1] / 2f;
+        float x = RuleBookRedirectManager.Instance.currentPageTopLeft.x;
+        float y = RuleBookRedirectManager.Instance.currentPageTopLeft.y;
+        float theta = RuleBookRedirectManager.Instance.currentPageRotation;
+        float tempX = x - cx;
+        float tempY = y - cy;
+
+        // now apply rotation
+        float rotatedX = tempX * Mathf.Cos(theta) - tempY * Mathf.Sin(theta);
+        float rotatedY = tempX * Mathf.Sin(theta) + tempY * Mathf.Cos(theta);
+
+        // translate back
+        x = rotatedX + cx;
+        y = rotatedY + cy;
+    }*/
+
+    public void SetRedirect(PageRangeType rangeType, string pageId)
+    {
+        redirectType = rangeType;
+        redirectId = pageId;
+    }
+
+    public override void OnAlternateSelectStarted()
+    {
+        RuleBookController.Instance.SetShown(true, redirectType != PageRangeType.Boons);
+        RuleBookPageInfo info = RuleBookController.Instance.PageData.Find(x =>
+            !string.IsNullOrEmpty(x.pageId)
+            && RuleBookManager.GetUnformattedPageId(x.pageId) == redirectId
+            && (redirectType != PageRangeType.Abilities || x.abilityPage)
+        );
+        int pageIndex = RuleBookController.Instance.PageData.IndexOf(info);
+        InscryptionAPIPlugin.Logger.LogDebug($"[PageTextSelected] Type:{redirectType} Id:{redirectId} Idx:[{pageIndex}] Null:{info == null}");
+
+        RuleBookRedirectManager.Instance.StopAllCoroutines();
+        RuleBookRedirectManager.Instance.StartCoroutine(RuleBookController.Instance.flipper.FlipToPage(pageIndex, 0.2f));
+    }
+}

--- a/InscryptionAPI/Rulebook/RuleBookManager.cs
+++ b/InscryptionAPI/Rulebook/RuleBookManager.cs
@@ -9,6 +9,9 @@ using System.Collections;
 using System.Collections.ObjectModel;
 using System.Reflection;
 using UnityEngine;
+using static InscryptionAPI.Boons.BoonManager;
+using static InscryptionAPI.Slots.SlotModificationManager;
+
 namespace InscryptionAPI.RuleBook;
 
 
@@ -295,4 +298,14 @@ public static class RuleBookManager
 
         return pageId;
     }
+
+    public static bool ItemShouldBeAdded(ConsumableItemData item, AbilityMetaCategory metaCategory)
+    {
+        return item.rulebookCategory == metaCategory || item.GetFullConsumableItemData()?.rulebookMetaCategories.Contains(metaCategory) == true;
+    }
+    public static bool BoonShouldBeAdded(FullBoon fullBoon, AbilityMetaCategory metaCategory)
+    {
+        return fullBoon?.boon?.icon != null && fullBoon.appearInRulebook && fullBoon.metaCategories.Contains(metaCategory);
+    }
+    public static bool SlotModShouldBeAdded(Info info, ModificationMetaCategory category) => info.RulebookName != null && info.MetaCategories.Contains(category);
 }

--- a/InscryptionAPI/Rulebook/RuleBookManager.cs
+++ b/InscryptionAPI/Rulebook/RuleBookManager.cs
@@ -299,6 +299,25 @@ public static class RuleBookManager
         return pageId;
     }
 
+    /// <summary>
+    /// Opens the rulebook to the page with the given pageId.
+    /// </summary>
+    /// <param name="instance">RuleBookController.Instance.</param>
+    /// <param name="pageId">The value to compare each rulebook pages' id against. If this starts with "[API_" then it will check against a page's unformatted id.</param>
+    /// <param name="offsetView">Whether to offset the camera view down when opening the rulebook.</param>
+    public static void OpenToCustomPage(this RuleBookController instance, string pageId, bool offsetView = false)
+    {
+        instance.SetShown(shown: true, offsetView);
+        int pageIndex = -1;
+        if (pageId.StartsWith(RuleBookManagerPatches.API_ID))
+            pageIndex = instance.PageData.IndexOf(instance.PageData.Find(x => !string.IsNullOrEmpty(x.pageId) && x.pageId == pageId));
+        else
+            pageIndex = instance.PageData.IndexOf(instance.PageData.Find(x => !string.IsNullOrEmpty(x.pageId) && GetUnformattedPageId(x.pageId) == pageId));
+
+        instance.StopAllCoroutines();
+        instance.StartCoroutine(instance.flipper.FlipToPage(pageIndex, 0.2f));
+    }
+
     public static bool ItemShouldBeAdded(ConsumableItemData item, AbilityMetaCategory metaCategory)
     {
         return item.rulebookCategory == metaCategory || item.GetFullConsumableItemData()?.rulebookMetaCategories.Contains(metaCategory) == true;

--- a/InscryptionAPI/Rulebook/RuleBookManagerPatches.cs
+++ b/InscryptionAPI/Rulebook/RuleBookManagerPatches.cs
@@ -8,7 +8,7 @@ using InscryptionAPI.Slots;
 using System.Reflection;
 using System.Reflection.Emit;
 using TMPro;
-using UnityEngine;
+
 using static InscryptionAPI.RuleBook.RuleBookManager;
 
 namespace InscryptionAPI.RuleBook;
@@ -112,7 +112,7 @@ public class RuleBookManagerPatches
     [HarmonyPatch(typeof(ItemPage), "FillPage")]
     private static bool FixFillPage(RuleBookPage __instance, string headerText, params object[] otherArgs)
     {
-        if (otherArgs?.Length > 0 && otherArgs.Last() is string pageId && pageId.StartsWith(API_ID))
+        if (otherArgs?.Length > 0 && otherArgs.LastOrDefault() is string pageId && pageId.StartsWith(API_ID))
         {
             string sectionId = pageId.Replace(API_ID, "");
             FullRuleBookRangeInfo fullInfo = AllRuleBookInfos.Find(x => sectionId.StartsWith(x.SubSectionName));

--- a/InscryptionAPI/Rulebook/RuleBookManagerPatches.cs
+++ b/InscryptionAPI/Rulebook/RuleBookManagerPatches.cs
@@ -1,6 +1,13 @@
 using DiskCardGame;
 using HarmonyLib;
+using InscryptionAPI.Boons;
+using InscryptionAPI.Card;
 using InscryptionAPI.Helpers.Extensions;
+using InscryptionAPI.Items;
+using InscryptionAPI.Slots;
+using System.Reflection;
+using System.Reflection.Emit;
+using TMPro;
 using UnityEngine;
 using static InscryptionAPI.RuleBook.RuleBookManager;
 
@@ -9,8 +16,10 @@ namespace InscryptionAPI.RuleBook;
 [HarmonyPatch]
 public class RuleBookManagerPatches
 {
+    public const string API_ID = "[API_";
+
     [HarmonyPatch(typeof(RuleBookInfo), "ConstructPageData", new Type[] { typeof(AbilityMetaCategory) })]
-    [HarmonyPostfix, HarmonyPriority(-100)]
+    [HarmonyPostfix, HarmonyPriority(Priority.Low)]
     private static void AddCustomRuleBookSections(AbilityMetaCategory metaCategory, RuleBookInfo __instance, ref List<RuleBookPageInfo> __result)
     {
         if (AllRuleBookInfos.Count == 0)
@@ -19,13 +28,11 @@ public class RuleBookManagerPatches
         foreach (PageRangeInfo pageRangeInfo in __instance.pageRanges)
         {
             List<FullRuleBookRangeInfo> rulebooksToCreate = AllRuleBookInfos.FindAll(x => x.PageTypeTemplate == pageRangeInfo.type);
-            //InscryptionAPIPlugin.Logger.LogDebug($"New infos for {pageRangeInfo.type}: {rulebooksToCreate.Count}");
             if (rulebooksToCreate.Count == 0)
                 continue;
 
             foreach (FullRuleBookRangeInfo rulebook in rulebooksToCreate)
             {
-                //InscryptionAPIPlugin.Logger.LogDebug($"Create new rulebook subsection: {rulebook.SubSectionName}");
                 int startingPageNum = rulebook.GetStartingNumber(__result);
                 int insertPosition = rulebook.GetInsertPosition(pageRangeInfo, __result);
 
@@ -34,8 +41,8 @@ public class RuleBookManagerPatches
                 foreach (RuleBookPageInfo page in newPages)
                 {
                     if (!page.pageId.StartsWith(API_ID))
-                        page.pageId = API_ID + $"{rulebook.SubSectionName}_" + page.pageId;
-                    
+                        page.pageId = string.Format("[API_{0}]", rulebook.SubSectionName) + page.pageId; // eg: [API_Tribes]Bird
+
                     page.pagePrefab = pageRangeInfo.rangePrefab;
                     page.headerText = string.Format(Localization.Translate(rulebook.FullHeaderText), startingPageNum);
                     __result.Insert(insertPosition, page);
@@ -46,52 +53,56 @@ public class RuleBookManagerPatches
         }
     }
 
-    public static void FillPage(RuleBookPage page, RuleBookPageInfo pageInfo)
+    [HarmonyPatch(typeof(RuleBookInfo), "ConstructPageData", new Type[] { typeof(AbilityMetaCategory) })]
+    [HarmonyPostfix, HarmonyPriority(Priority.Last)]
+    private static void SyncRuleBookRedirectsForEachPage(List<RuleBookPageInfo> __result)
     {
-        if (page is AbilityPage)
+        ConstructedPagesWithRedirects.Clear();
+        foreach (RuleBookPageInfo info in __result)
         {
-            page.FillPage(pageInfo.headerText, pageInfo.ability, pageInfo.fillerAbilityIds, pageInfo.pageId);
-        }
-        else if (page is BoonPage)
-        {
-            page.FillPage(pageInfo.headerText, pageInfo.boon, pageInfo.pageId);
-        }
-        else
-        {
-            page.FillPage(pageInfo.headerText, pageInfo.pageId);
-        }
-    }
-
-    private const string API_ID = "API_";
-
-    [HarmonyPrefix, HarmonyPatch(typeof(PageContentLoader), nameof(PageContentLoader.LoadPage))]
-    private static bool LoadCustomPage(PageContentLoader __instance, RuleBookPageInfo pageInfo)
-    {
-        if (__instance.currentPagePrefab != pageInfo.pagePrefab)
-        {
-            if (__instance.currentPageObj != null)
-                UnityObject.Destroy(__instance.currentPageObj);
-
-            __instance.currentPageObj = UnityObject.Instantiate(pageInfo.pagePrefab, __instance.transform.position, __instance.transform.rotation, __instance.transform);
-        }
-        __instance.currentPagePrefab = pageInfo.pagePrefab;
-        foreach (GameObject currentAdditiveObject in __instance.currentAdditiveObjects)
-        {
-            UnityObject.Destroy(currentAdditiveObject);
-        }
-        __instance.currentAdditiveObjects.Clear();
-        foreach (GameObject additivePrefab in pageInfo.additivePrefabs)
-        {
-            if (additivePrefab != null)
+            Dictionary<string, RedirectInfo> redirectInfos = null;
+            RuleBookPageInfoExt ext = CustomRedirectPages.Find(x => x.parentPageInfo == info);
+            if (ext != null)
             {
-                GameObject gameObject = UnityObject.Instantiate(additivePrefab, __instance.transform.position, __instance.transform.rotation, __instance.transform);
-                gameObject.SetActive(value: true);
-                __instance.currentAdditiveObjects.Add(gameObject);
+                redirectInfos = ext.RulebookDescriptionRedirects;
+            }
+            else if (info.ability > 0)
+            {
+                AbilityManager.FullAbility full = AbilityManager.AllAbilities.AbilityByID(info.ability);
+                redirectInfos = full?.RulebookDescriptionRedirects;
+            }
+            else if (info.boon > 0)
+            {
+                BoonManager.FullBoon boon = BoonManager.AllFullBoons.Find(x => x.boon.type == info.boon);
+                redirectInfos = boon?.RulebookDescriptionRedirects;
+            }
+            else if (!string.IsNullOrEmpty(info.pageId) && !info.pageId.StartsWith(API_ID))
+            {
+                // custom rulebook pages can have their redirects created during initialisation, this only handles vanilla logic
+                string pureId = GetUnformattedPageId(info.pageId);
+                StatIconManager.FullStatIcon icon = StatIconManager.AllStatIcons.Find(x => x.Id.ToString() == pureId);
+                if (icon != null)
+                {
+                    redirectInfos = icon.RulebookDescriptionRedirects;
+                }
+                else if (info.pageId.StartsWith(SlotModificationManager.SLOT_PAGEID))
+                {
+                    string slotId = info.pageId.Replace(SlotModificationManager.SLOT_PAGEID, "");
+                    SlotModificationManager.Info slot = SlotModificationManager.AllModificationInfos.Find(x => x.ModificationType.ToString() == slotId);
+                    redirectInfos = slot?.RulebookDescriptionRedirects;
+                }
+                else
+                {
+                    ConsumableItemManager.FullConsumableItemData fullItem = ConsumableItemManager.allFullItemDatas.Find(x => x.itemData.name == pureId);
+                    redirectInfos = fullItem?.RulebookDescriptionRedirects;
+                }
+            }
+
+            if (redirectInfos != null && redirectInfos.Count > 0)
+            {
+                AddRedirectPage(info, new(redirectInfos));
             }
         }
-        RuleBookPage component = __instance.currentPageObj.GetComponent<RuleBookPage>();
-        FillPage(component, pageInfo);
-        return false;
     }
 
     [HarmonyPrefix]
@@ -99,13 +110,13 @@ public class RuleBookManagerPatches
     [HarmonyPatch(typeof(StatIconPage), "FillPage")]
     [HarmonyPatch(typeof(BoonPage), "FillPage")]
     [HarmonyPatch(typeof(ItemPage), "FillPage")]
-    private static bool FixFillAbilityPage(RuleBookPage __instance, string headerText, params object[] otherArgs)
+    private static bool FixFillPage(RuleBookPage __instance, string headerText, params object[] otherArgs)
     {
-        if (otherArgs != null && otherArgs.Last() is string pageId && pageId.StartsWith(API_ID))
+        if (otherArgs?.Length > 0 && otherArgs.Last() is string pageId && pageId.StartsWith(API_ID))
         {
-            pageId = pageId.Replace(API_ID, "");
-            FullRuleBookRangeInfo fullInfo = AllRuleBookInfos.Find(x => pageId.StartsWith(x.SubSectionName));
-            if (fullInfo != null && fullInfo.FillPageAction != null)
+            string sectionId = pageId.Replace(API_ID, "");
+            FullRuleBookRangeInfo fullInfo = AllRuleBookInfos.Find(x => sectionId.StartsWith(x.SubSectionName));
+            if (fullInfo?.FillPageAction != null)
             {
                 if (__instance.headerTextMesh != null)
                     __instance.headerTextMesh.text = headerText;
@@ -113,10 +124,62 @@ public class RuleBookManagerPatches
                 List<object> obj = otherArgs.ToList();
                 obj.PopLast();
 
-                fullInfo.FillRuleBookPage(__instance, pageId.Replace(fullInfo.SubSectionName + "_", ""), obj.ToArray());
+                fullInfo.FillRuleBookPage(__instance, GetUnformattedPageId(pageId), obj.ToArray());
                 return false;
             }
         }
         return true;
+    }
+
+    [HarmonyTranspiler, HarmonyPatch(typeof(PageContentLoader), nameof(PageContentLoader.LoadPage))]
+    private static IEnumerable<CodeInstruction> LoadCustomPage(IEnumerable<CodeInstruction> instructions)
+    {
+        List<CodeInstruction> codes = new(instructions);
+        int startIndex = codes.IndexOf(codes.Find(x => x.opcode == OpCodes.Stloc_0));
+        if (startIndex != -1)
+        {
+            startIndex += 2;
+            codes.RemoveRange(startIndex, codes.Count - startIndex - 1);
+            MethodInfo method = AccessTools.Method(typeof(RuleBookManagerPatches), nameof(RuleBookManagerPatches.FillPage), new Type[] { typeof(RuleBookPage), typeof(RuleBookPageInfo) });
+            codes.Insert(startIndex++, new(OpCodes.Ldarg_1));
+            codes.Insert(startIndex++, new(OpCodes.Call, method));
+        }
+        return codes;
+    }
+
+    /// <summary>
+    /// Expanded version of FillPage that accounts for custom rulebook sections.
+    /// </summary>
+    public static void FillPage(RuleBookPage page, RuleBookPageInfo pageInfo)
+    {
+        TextMeshPro descriptionTextMesh = null;
+        if (page is AbilityPage ab)
+        {
+            ab.FillPage(pageInfo.headerText, pageInfo.ability, pageInfo.fillerAbilityIds, pageInfo.pageId);
+            descriptionTextMesh = ab.mainAbilityGroup.descriptionTextMesh;
+        }
+        else if (page is BoonPage bn)
+        {
+            bn.FillPage(pageInfo.headerText, pageInfo.boon, pageInfo.pageId);
+            descriptionTextMesh = bn.descriptionTextMesh;
+        }
+        else
+        {
+            page.FillPage(pageInfo.headerText, pageInfo.pageId);
+            if (page is ItemPage im)
+            {
+                descriptionTextMesh = im.descriptionTextMesh;
+            }
+            else if (page is StatIconPage si)
+            {
+                descriptionTextMesh = si.descriptionTextMesh;
+            }
+        }
+
+        RuleBookPageInfoExt ext = ConstructedPagesWithRedirects.Find(x => x.parentPageInfo == pageInfo);
+        if (ext != null && descriptionTextMesh != null)
+        {
+            descriptionTextMesh.text = ParseRedirectTextColours(ext.RulebookDescriptionRedirects, descriptionTextMesh.text);
+        }
     }
 }

--- a/InscryptionAPI/Rulebook/RuleBookRedirectExtensions.cs
+++ b/InscryptionAPI/Rulebook/RuleBookRedirectExtensions.cs
@@ -6,7 +6,7 @@ using InscryptionAPI.Slots;
 using UnityEngine;
 using static InscryptionAPI.RuleBook.RuleBookManager;
 
-namespace InscryptionAPI.Rulebook;
+namespace InscryptionAPI.RuleBook;
 
 public static class RuleBookRedirectExtensions
 {
@@ -44,7 +44,7 @@ public static class RuleBookRedirectExtensions
 
     public static AbilityInfo SetAbilityRedirect(this AbilityInfo info, string clickableText, Ability abilityRedirect, Color redirectColour)
     {
-        AbilityManager.FullAbility full = AbilityManager.BaseGameAbilities.Concat(AbilityManager.NewAbilities).First(x => x.Info.ability == info.ability);
+        AbilityManager.FullAbility full = AbilityManager.BaseGameAbilities.Concat(AbilityManager.NewAbilities).FirstOrDefault(x => x.Info.ability == info.ability);
         if (full != null)
         {
             full.SetAbilityRedirect(clickableText, abilityRedirect, redirectColour);
@@ -56,7 +56,7 @@ public static class RuleBookRedirectExtensions
     }
     public static AbilityInfo SetStatIconRedirect(this AbilityInfo info, string clickableText, SpecialStatIcon statIconRedirect, Color redirectColour)
     {
-        AbilityManager.FullAbility full = AbilityManager.BaseGameAbilities.Concat(AbilityManager.NewAbilities).First(x => x.Info.ability == info.ability);
+        AbilityManager.FullAbility full = AbilityManager.BaseGameAbilities.Concat(AbilityManager.NewAbilities).FirstOrDefault(x => x.Info.ability == info.ability);
         if (full != null)
         {
             full.SetStatIconRedirect(clickableText, statIconRedirect, redirectColour);
@@ -68,7 +68,7 @@ public static class RuleBookRedirectExtensions
     }
     public static AbilityInfo SetBoonRedirect(this AbilityInfo info, string clickableText, BoonData.Type boonRedirect, Color redirectColour)
     {
-        AbilityManager.FullAbility full = AbilityManager.BaseGameAbilities.Concat(AbilityManager.NewAbilities).First(x => x.Info.ability == info.ability);
+        AbilityManager.FullAbility full = AbilityManager.BaseGameAbilities.Concat(AbilityManager.NewAbilities).FirstOrDefault(x => x.Info.ability == info.ability);
         if (full != null)
         {
             full.SetBoonRedirect(clickableText, boonRedirect, redirectColour);
@@ -80,7 +80,7 @@ public static class RuleBookRedirectExtensions
     }
     public static AbilityInfo SetItemRedirect(this AbilityInfo info, string clickableText, string itemNameRedirect, Color redirectColour)
     {
-        AbilityManager.FullAbility full = AbilityManager.BaseGameAbilities.Concat(AbilityManager.NewAbilities).First(x => x.Info.ability == info.ability);
+        AbilityManager.FullAbility full = AbilityManager.BaseGameAbilities.Concat(AbilityManager.NewAbilities).FirstOrDefault(x => x.Info.ability == info.ability);
         if (full != null)
         {
             full.SetItemRedirect(clickableText, itemNameRedirect, redirectColour);
@@ -92,7 +92,7 @@ public static class RuleBookRedirectExtensions
     }
     public static AbilityInfo SetUniqueRedirect(this AbilityInfo info, string clickableText, string uniqueRedirect, Color redirectColour)
     {
-        AbilityManager.FullAbility full = AbilityManager.BaseGameAbilities.Concat(AbilityManager.NewAbilities).First(x => x.Info.ability == info.ability);
+        AbilityManager.FullAbility full = AbilityManager.BaseGameAbilities.Concat(AbilityManager.NewAbilities).FirstOrDefault(x => x.Info.ability == info.ability);
         if (full != null)
         {
             full.SetUniqueRedirect(clickableText, uniqueRedirect, redirectColour);
@@ -104,7 +104,7 @@ public static class RuleBookRedirectExtensions
     }
     public static AbilityInfo SetSlotRedirect(this AbilityInfo info, string clickableText, SlotModificationManager.ModificationType slotMod, Color redirectColour)
     {
-        AbilityManager.FullAbility full = AbilityManager.BaseGameAbilities.Concat(AbilityManager.NewAbilities).First(x => x.Info.ability == info.ability);
+        AbilityManager.FullAbility full = AbilityManager.BaseGameAbilities.Concat(AbilityManager.NewAbilities).FirstOrDefault(x => x.Info.ability == info.ability);
         if (full != null)
         {
             full.SetSlotRedirect(clickableText, slotMod, redirectColour);

--- a/InscryptionAPI/Rulebook/RuleBookRedirectExtensions.cs
+++ b/InscryptionAPI/Rulebook/RuleBookRedirectExtensions.cs
@@ -2,6 +2,7 @@ using DiskCardGame;
 using InscryptionAPI.Boons;
 using InscryptionAPI.Card;
 using InscryptionAPI.Items;
+using InscryptionAPI.Slots;
 using UnityEngine;
 using static InscryptionAPI.RuleBook.RuleBookManager;
 
@@ -33,6 +34,11 @@ public static class RuleBookRedirectExtensions
     public static AbilityManager.FullAbility SetUniqueRedirect(this AbilityManager.FullAbility fullAbility, string clickableText, string uniqueRedirect, Color redirectColour)
     {
         fullAbility.RulebookDescriptionRedirects[clickableText] = new(PageRangeType.Unique, redirectColour, uniqueRedirect);
+        return fullAbility;
+    }
+    public static AbilityManager.FullAbility SetSlotRedirect(this AbilityManager.FullAbility fullAbility, string clickableText, SlotModificationManager.ModificationType slotMod, Color redirectColour)
+    {
+        fullAbility.RulebookDescriptionRedirects[clickableText] = new(PageRangeType.Items, redirectColour, SlotModificationManager.SLOT_PAGEID + slotMod.ToString());
         return fullAbility;
     }
 
@@ -96,6 +102,18 @@ public static class RuleBookRedirectExtensions
         InscryptionAPIPlugin.Logger.LogError($"Can't set rulebook redirect for {clickableText} because the AbilityInfo hasn't been added to the API yet.");
         return info;
     }
+    public static AbilityInfo SetSlotRedirect(this AbilityInfo info, string clickableText, SlotModificationManager.ModificationType slotMod, Color redirectColour)
+    {
+        AbilityManager.FullAbility full = AbilityManager.BaseGameAbilities.Concat(AbilityManager.NewAbilities).First(x => x.Info.ability == info.ability);
+        if (full != null)
+        {
+            full.SetSlotRedirect(clickableText, slotMod, redirectColour);
+            return info;
+        }
+
+        InscryptionAPIPlugin.Logger.LogError($"Can't set rulebook redirect for {clickableText} because the AbilityInfo hasn't been added to the API yet.");
+        return info;
+    }
     #endregion
 
     #region StatIconInfo
@@ -122,6 +140,11 @@ public static class RuleBookRedirectExtensions
     public static StatIconManager.FullStatIcon SetUniqueRedirect(this StatIconManager.FullStatIcon fullIcon, string clickableText, string uniqueRedirect, Color redirectColour)
     {
         fullIcon.RulebookDescriptionRedirects[clickableText] = new(PageRangeType.Unique, redirectColour, uniqueRedirect);
+        return fullIcon;
+    }
+    public static StatIconManager.FullStatIcon SetSlotRedirect(this StatIconManager.FullStatIcon fullIcon, string clickableText, SlotModificationManager.ModificationType slotMod, Color redirectColour)
+    {
+        fullIcon.RulebookDescriptionRedirects[clickableText] = new(PageRangeType.Items, redirectColour, SlotModificationManager.SLOT_PAGEID + slotMod.ToString());
         return fullIcon;
     }
 
@@ -185,6 +208,18 @@ public static class RuleBookRedirectExtensions
         InscryptionAPIPlugin.Logger.LogError($"Can't set rulebook redirect for {clickableText} because the StatIconInfo hasn't been added to the API yet.");
         return info;
     }
+    public static StatIconInfo SetSlotRedirect(this StatIconInfo info, string clickableText, SlotModificationManager.ModificationType slotMod, Color redirectColour)
+    {
+        StatIconManager.FullStatIcon full = StatIconManager.AllStatIcons.Find(x => x.Id == info.iconType);
+        if (full != null)
+        {
+            full.SetSlotRedirect(clickableText, slotMod, redirectColour);
+            return info;
+        }
+
+        InscryptionAPIPlugin.Logger.LogError($"Can't set rulebook redirect for {clickableText} because the StatIconInfo hasn't been added to the API yet.");
+        return info;
+    }
     #endregion
 
     #region BoonData
@@ -211,6 +246,11 @@ public static class RuleBookRedirectExtensions
     public static BoonManager.FullBoon SetUniqueRedirect(this BoonManager.FullBoon fullBoon, string clickableText, string uniqueRedirect, Color redirectColour)
     {
         fullBoon.RulebookDescriptionRedirects[clickableText] = new(PageRangeType.Unique, redirectColour, uniqueRedirect);
+        return fullBoon;
+    }
+    public static BoonManager.FullBoon SetSlotRedirect(this BoonManager.FullBoon fullBoon, string clickableText, SlotModificationManager.ModificationType slotMod, Color redirectColour)
+    {
+        fullBoon.RulebookDescriptionRedirects[clickableText] = new(PageRangeType.Items, redirectColour, SlotModificationManager.SLOT_PAGEID + slotMod.ToString());
         return fullBoon;
     }
 
@@ -274,6 +314,18 @@ public static class RuleBookRedirectExtensions
         InscryptionAPIPlugin.Logger.LogError($"Can't set rulebook redirect for {clickableText} because the BoonData hasn't been added to the API yet.");
         return info;
     }
+    public static BoonData SetSlotRedirect(this BoonData info, string clickableText, SlotModificationManager.ModificationType slotMod, Color redirectColour)
+    {
+        BoonManager.FullBoon full = BoonManager.AllFullBoons.Find(x => x.boon.type == info.type);
+        if (full != null)
+        {
+            full.SetSlotRedirect(clickableText, slotMod, redirectColour);
+            return info;
+        }
+
+        InscryptionAPIPlugin.Logger.LogError($"Can't set rulebook redirect for {clickableText} because the BoonData hasn't been added to the API yet.");
+        return info;
+    }
     #endregion
 
     #region ConsumableItemData
@@ -300,6 +352,11 @@ public static class RuleBookRedirectExtensions
     public static ConsumableItemManager.FullConsumableItemData SetUniqueRedirect(this ConsumableItemManager.FullConsumableItemData fullItem, string clickableText, string uniqueRedirect, Color redirectColour)
     {
         fullItem.RulebookDescriptionRedirects[clickableText] = new(PageRangeType.Unique, redirectColour, uniqueRedirect);
+        return fullItem;
+    }
+    public static ConsumableItemManager.FullConsumableItemData SetSlotRedirect(this ConsumableItemManager.FullConsumableItemData fullItem, string clickableText, SlotModificationManager.ModificationType slotMod, Color redirectColour)
+    {
+        fullItem.RulebookDescriptionRedirects[clickableText] = new(PageRangeType.Items, redirectColour, SlotModificationManager.SLOT_PAGEID + slotMod.ToString());
         return fullItem;
     }
 
@@ -363,6 +420,124 @@ public static class RuleBookRedirectExtensions
         InscryptionAPIPlugin.Logger.LogError($"Can't set rulebook redirect for {clickableText} because the ConsumableItemData hasn't been added to the API yet.");
         return info;
     }
+    public static ConsumableItemData SetSlotRedirect(this ConsumableItemData info, string clickableText, SlotModificationManager.ModificationType slotMod, Color redirectColour)
+    {
+        ConsumableItemManager.FullConsumableItemData full = ConsumableItemManager.allFullItemDatas.Find(x => x.itemData == info);
+        if (full != null)
+        {
+            full.SetSlotRedirect(clickableText, slotMod, redirectColour);
+            return info;
+        }
+
+        InscryptionAPIPlugin.Logger.LogError($"Can't set rulebook redirect for {clickableText} because the ConsumableItemData hasn't been added to the API yet.");
+        return info;
+    }
+    #endregion
+
+    #region SlotMod
+    public static SlotModificationManager.Info SetAbilityRedirect(this SlotModificationManager.Info slotInfo, string clickableText, Ability abilityRedirect, Color redirectColour)
+    {
+        slotInfo.RulebookDescriptionRedirects[clickableText] = new(PageRangeType.Abilities, redirectColour, abilityRedirect.ToString());
+        return slotInfo;
+    }
+    public static SlotModificationManager.Info SetStatIconRedirect(this SlotModificationManager.Info slotInfo, string clickableText, SpecialStatIcon statIconRedirect, Color redirectColour)
+    {
+        slotInfo.RulebookDescriptionRedirects[clickableText] = new(PageRangeType.StatIcons, redirectColour, statIconRedirect.ToString());
+        return slotInfo;
+    }
+    public static SlotModificationManager.Info SetBoonRedirect(this SlotModificationManager.Info slotInfo, string clickableText, BoonData.Type boonRedirect, Color redirectColour)
+    {
+        slotInfo.RulebookDescriptionRedirects[clickableText] = new(PageRangeType.Boons, redirectColour, boonRedirect.ToString());
+        return slotInfo;
+    }
+    public static SlotModificationManager.Info SetItemRedirect(this SlotModificationManager.Info slotInfo, string clickableText, string itemNameRedirect, Color redirectColour)
+    {
+        slotInfo.RulebookDescriptionRedirects[clickableText] = new(PageRangeType.Items, redirectColour, itemNameRedirect);
+        return slotInfo;
+    }
+    public static SlotModificationManager.Info SetUniqueRedirect(this SlotModificationManager.Info slotInfo, string clickableText, string uniqueRedirect, Color redirectColour)
+    {
+        slotInfo.RulebookDescriptionRedirects[clickableText] = new(PageRangeType.Unique, redirectColour, uniqueRedirect);
+        return slotInfo;
+    }
+    public static SlotModificationManager.Info SetSlotRedirect(this SlotModificationManager.Info slotInfo, string clickableText, SlotModificationManager.ModificationType slotMod, Color redirectColour)
+    {
+        slotInfo.RulebookDescriptionRedirects[clickableText] = new(PageRangeType.Items, redirectColour, SlotModificationManager.SLOT_PAGEID + slotMod.ToString());
+        return slotInfo;
+    }
+
+    public static SlotModificationManager.ModificationType SetAbilityRedirect(this SlotModificationManager.ModificationType info, string clickableText, Ability abilityRedirect, Color redirectColour)
+    {
+        SlotModificationManager.Info full = SlotModificationManager.AllSlotModifications.InfoByID(info);
+        if (full != null)
+        {
+            full.SetAbilityRedirect(clickableText, abilityRedirect, redirectColour);
+            return info;
+        }
+
+        InscryptionAPIPlugin.Logger.LogError($"Can't set rulebook redirect for {clickableText} because the SlotModificationManager.ModificationType hasn't been added to the API yet.");
+        return info;
+    }
+    public static SlotModificationManager.ModificationType SetStatIconRedirect(this SlotModificationManager.ModificationType info, string clickableText, SpecialStatIcon statIconRedirect, Color redirectColour)
+    {
+        SlotModificationManager.Info full = SlotModificationManager.AllSlotModifications.InfoByID(info);
+        if (full != null)
+        {
+            full.SetStatIconRedirect(clickableText, statIconRedirect, redirectColour);
+            return info;
+        }
+
+        InscryptionAPIPlugin.Logger.LogError($"Can't set rulebook redirect for {clickableText} because the SlotModificationManager.ModificationType hasn't been added to the API yet.");
+        return info;
+    }
+    public static SlotModificationManager.ModificationType SetBoonRedirect(this SlotModificationManager.ModificationType info, string clickableText, BoonData.Type boonRedirect, Color redirectColour)
+    {
+        SlotModificationManager.Info full = SlotModificationManager.AllSlotModifications.InfoByID(info);
+        if (full != null)
+        {
+            full.SetBoonRedirect(clickableText, boonRedirect, redirectColour);
+            return info;
+        }
+
+        InscryptionAPIPlugin.Logger.LogError($"Can't set rulebook redirect for {clickableText} because the ConsumableItemData hasn't been added to the API yet.");
+        return info;
+    }
+    public static SlotModificationManager.ModificationType SetItemRedirect(this SlotModificationManager.ModificationType info, string clickableText, string itemNameRedirect, Color redirectColour)
+    {
+        SlotModificationManager.Info full = SlotModificationManager.AllSlotModifications.InfoByID(info);
+        if (full != null)
+        {
+            full.SetItemRedirect(clickableText, itemNameRedirect, redirectColour);
+            return info;
+        }
+
+        InscryptionAPIPlugin.Logger.LogError($"Can't set rulebook redirect for {clickableText} because the SlotModificationManager.ModificationType hasn't been added to the API yet.");
+        return info;
+    }
+    public static SlotModificationManager.ModificationType SetUniqueRedirect(this SlotModificationManager.ModificationType info, string clickableText, string uniqueRedirect, Color redirectColour)
+    {
+        SlotModificationManager.Info full = SlotModificationManager.AllSlotModifications.InfoByID(info);
+        if (full != null)
+        {
+            full.SetUniqueRedirect(clickableText, uniqueRedirect, redirectColour);
+            return info;
+        }
+
+        InscryptionAPIPlugin.Logger.LogError($"Can't set rulebook redirect for {clickableText} because the SlotModificationManager.ModificationType hasn't been added to the API yet.");
+        return info;
+    }
+    public static SlotModificationManager.ModificationType SetSlotRedirect(this SlotModificationManager.ModificationType info, string clickableText, SlotModificationManager.ModificationType slotMod, Color redirectColour)
+    {
+        SlotModificationManager.Info full = SlotModificationManager.AllSlotModifications.InfoByID(info);
+        if (full != null)
+        {
+            full.SetSlotRedirect(clickableText, slotMod, redirectColour);
+            return info;
+        }
+
+        InscryptionAPIPlugin.Logger.LogError($"Can't set rulebook redirect for {clickableText} because the SlotModificationManager.ModificationType hasn't been added to the API yet.");
+        return info;
+    }
     #endregion
 
     #region RuleBookPageInfo
@@ -419,6 +594,17 @@ public static class RuleBookRedirectExtensions
             CustomRedirectPages.Add(ext);
         }
         ext.RulebookDescriptionRedirects[clickableText] = new(PageRangeType.Unique, redirectColour, uniqueRedirect);
+        return pageInfo;
+    }
+    public static RuleBookPageInfo SetSlotRedirect(this RuleBookPageInfo pageInfo, string clickableText, SlotModificationManager.ModificationType slotMod, Color redirectColour)
+    {
+        RuleBookPageInfoExt ext = CustomRedirectPages.Find(x => x.parentPageInfo == pageInfo);
+        if (ext == null)
+        {
+            ext = new(pageInfo, new());
+            CustomRedirectPages.Add(ext);
+        }
+        ext.RulebookDescriptionRedirects[clickableText] = new(PageRangeType.Items, redirectColour, SlotModificationManager.SLOT_PAGEID + slotMod.ToString());
         return pageInfo;
     }
     #endregion

--- a/InscryptionAPI/Rulebook/RuleBookRedirectExtensions.cs
+++ b/InscryptionAPI/Rulebook/RuleBookRedirectExtensions.cs
@@ -1,0 +1,425 @@
+using DiskCardGame;
+using InscryptionAPI.Boons;
+using InscryptionAPI.Card;
+using InscryptionAPI.Items;
+using UnityEngine;
+using static InscryptionAPI.RuleBook.RuleBookManager;
+
+namespace InscryptionAPI.Rulebook;
+
+public static class RuleBookRedirectExtensions
+{
+    #region AbilityInfo
+    public static AbilityManager.FullAbility SetAbilityRedirect(this AbilityManager.FullAbility fullAbility, string clickableText, Ability abilityRedirect, Color redirectColour)
+    {
+        fullAbility.RulebookDescriptionRedirects[clickableText] = new(PageRangeType.Abilities, redirectColour, abilityRedirect.ToString());
+        return fullAbility;
+    }
+    public static AbilityManager.FullAbility SetStatIconRedirect(this AbilityManager.FullAbility fullAbility, string clickableText, SpecialStatIcon statIconRedirect, Color redirectColour)
+    {
+        fullAbility.RulebookDescriptionRedirects[clickableText] = new(PageRangeType.StatIcons, redirectColour, statIconRedirect.ToString());
+        return fullAbility;
+    }
+    public static AbilityManager.FullAbility SetBoonRedirect(this AbilityManager.FullAbility fullAbility, string clickableText, BoonData.Type boonRedirect, Color redirectColour)
+    {
+        fullAbility.RulebookDescriptionRedirects[clickableText] = new(PageRangeType.Boons, redirectColour, boonRedirect.ToString());
+        return fullAbility;
+    }
+    public static AbilityManager.FullAbility SetItemRedirect(this AbilityManager.FullAbility fullAbility, string clickableText, string itemNameRedirect, Color redirectColour)
+    {
+        fullAbility.RulebookDescriptionRedirects[clickableText] = new(PageRangeType.Items, redirectColour, itemNameRedirect);
+        return fullAbility;
+    }
+    public static AbilityManager.FullAbility SetUniqueRedirect(this AbilityManager.FullAbility fullAbility, string clickableText, string uniqueRedirect, Color redirectColour)
+    {
+        fullAbility.RulebookDescriptionRedirects[clickableText] = new(PageRangeType.Unique, redirectColour, uniqueRedirect);
+        return fullAbility;
+    }
+
+    public static AbilityInfo SetAbilityRedirect(this AbilityInfo info, string clickableText, Ability abilityRedirect, Color redirectColour)
+    {
+        AbilityManager.FullAbility full = AbilityManager.BaseGameAbilities.Concat(AbilityManager.NewAbilities).First(x => x.Info.ability == info.ability);
+        if (full != null)
+        {
+            full.SetAbilityRedirect(clickableText, abilityRedirect, redirectColour);
+            return info;
+        }
+
+        InscryptionAPIPlugin.Logger.LogError($"Can't set rulebook redirect for {clickableText} because the AbilityInfo hasn't been added to the API yet.");
+        return info;
+    }
+    public static AbilityInfo SetStatIconRedirect(this AbilityInfo info, string clickableText, SpecialStatIcon statIconRedirect, Color redirectColour)
+    {
+        AbilityManager.FullAbility full = AbilityManager.BaseGameAbilities.Concat(AbilityManager.NewAbilities).First(x => x.Info.ability == info.ability);
+        if (full != null)
+        {
+            full.SetStatIconRedirect(clickableText, statIconRedirect, redirectColour);
+            return info;
+        }
+
+        InscryptionAPIPlugin.Logger.LogError($"Can't set rulebook redirect for {clickableText} because the AbilityInfo hasn't been added to the API yet.");
+        return info;
+    }
+    public static AbilityInfo SetBoonRedirect(this AbilityInfo info, string clickableText, BoonData.Type boonRedirect, Color redirectColour)
+    {
+        AbilityManager.FullAbility full = AbilityManager.BaseGameAbilities.Concat(AbilityManager.NewAbilities).First(x => x.Info.ability == info.ability);
+        if (full != null)
+        {
+            full.SetBoonRedirect(clickableText, boonRedirect, redirectColour);
+            return info;
+        }
+
+        InscryptionAPIPlugin.Logger.LogError($"Can't set rulebook redirect for {clickableText} because the AbilityInfo hasn't been added to the API yet.");
+        return info;
+    }
+    public static AbilityInfo SetItemRedirect(this AbilityInfo info, string clickableText, string itemNameRedirect, Color redirectColour)
+    {
+        AbilityManager.FullAbility full = AbilityManager.BaseGameAbilities.Concat(AbilityManager.NewAbilities).First(x => x.Info.ability == info.ability);
+        if (full != null)
+        {
+            full.SetItemRedirect(clickableText, itemNameRedirect, redirectColour);
+            return info;
+        }
+
+        InscryptionAPIPlugin.Logger.LogError($"Can't set rulebook redirect for {clickableText} because the AbilityInfo hasn't been added to the API yet.");
+        return info;
+    }
+    public static AbilityInfo SetUniqueRedirect(this AbilityInfo info, string clickableText, string uniqueRedirect, Color redirectColour)
+    {
+        AbilityManager.FullAbility full = AbilityManager.BaseGameAbilities.Concat(AbilityManager.NewAbilities).First(x => x.Info.ability == info.ability);
+        if (full != null)
+        {
+            full.SetUniqueRedirect(clickableText, uniqueRedirect, redirectColour);
+            return info;
+        }
+
+        InscryptionAPIPlugin.Logger.LogError($"Can't set rulebook redirect for {clickableText} because the AbilityInfo hasn't been added to the API yet.");
+        return info;
+    }
+    #endregion
+
+    #region StatIconInfo
+    public static StatIconManager.FullStatIcon SetAbilityRedirect(this StatIconManager.FullStatIcon fullIcon, string clickableText, Ability abilityRedirect, Color redirectColour)
+    {
+        fullIcon.RulebookDescriptionRedirects[clickableText] = new(PageRangeType.Abilities, redirectColour, abilityRedirect.ToString());
+        return fullIcon;
+    }
+    public static StatIconManager.FullStatIcon SetStatIconRedirect(this StatIconManager.FullStatIcon fullIcon, string clickableText, SpecialStatIcon statIconRedirect, Color redirectColour)
+    {
+        fullIcon.RulebookDescriptionRedirects[clickableText] = new(PageRangeType.StatIcons, redirectColour, statIconRedirect.ToString());
+        return fullIcon;
+    }
+    public static StatIconManager.FullStatIcon SetBoonRedirect(this StatIconManager.FullStatIcon fullIcon, string clickableText, BoonData.Type boonRedirect, Color redirectColour)
+    {
+        fullIcon.RulebookDescriptionRedirects[clickableText] = new(PageRangeType.Boons, redirectColour, boonRedirect.ToString());
+        return fullIcon;
+    }
+    public static StatIconManager.FullStatIcon SetItemRedirect(this StatIconManager.FullStatIcon fullIcon, string clickableText, string itemNameRedirect, Color redirectColour)
+    {
+        fullIcon.RulebookDescriptionRedirects[clickableText] = new(PageRangeType.Items, redirectColour, itemNameRedirect);
+        return fullIcon;
+    }
+    public static StatIconManager.FullStatIcon SetUniqueRedirect(this StatIconManager.FullStatIcon fullIcon, string clickableText, string uniqueRedirect, Color redirectColour)
+    {
+        fullIcon.RulebookDescriptionRedirects[clickableText] = new(PageRangeType.Unique, redirectColour, uniqueRedirect);
+        return fullIcon;
+    }
+
+    public static StatIconInfo SetAbilityRedirect(this StatIconInfo info, string clickableText, Ability abilityRedirect, Color redirectColour)
+    {
+        StatIconManager.FullStatIcon full = StatIconManager.AllStatIcons.Find(x => x.Id == info.iconType);
+        if (full != null)
+        {
+            full.SetAbilityRedirect(clickableText, abilityRedirect, redirectColour);
+            return info;
+        }
+
+        InscryptionAPIPlugin.Logger.LogError($"Can't set rulebook redirect for {clickableText} because the StatIconInfo hasn't been added to the API yet.");
+        return info;
+    }
+    public static StatIconInfo SetStatIconRedirect(this StatIconInfo info, string clickableText, SpecialStatIcon statIconRedirect, Color redirectColour)
+    {
+        StatIconManager.FullStatIcon full = StatIconManager.AllStatIcons.Find(x => x.Id == info.iconType);
+        if (full != null)
+        {
+            full.SetStatIconRedirect(clickableText, statIconRedirect, redirectColour);
+            return info;
+        }
+
+        InscryptionAPIPlugin.Logger.LogError($"Can't set rulebook redirect for {clickableText} because the StatIconInfo hasn't been added to the API yet.");
+        return info;
+    }
+    public static StatIconInfo SetBoonRedirect(this StatIconInfo info, string clickableText, BoonData.Type boonRedirect, Color redirectColour)
+    {
+        StatIconManager.FullStatIcon full = StatIconManager.AllStatIcons.Find(x => x.Id == info.iconType);
+        if (full != null)
+        {
+            full.SetBoonRedirect(clickableText, boonRedirect, redirectColour);
+            return info;
+        }
+
+        InscryptionAPIPlugin.Logger.LogError($"Can't set rulebook redirect for {clickableText} because the StatIconInfo hasn't been added to the API yet.");
+        return info;
+    }
+    public static StatIconInfo SetItemRedirect(this StatIconInfo info, string clickableText, string itemNameRedirect, Color redirectColour)
+    {
+        StatIconManager.FullStatIcon full = StatIconManager.AllStatIcons.Find(x => x.Id == info.iconType);
+        if (full != null)
+        {
+            full.SetItemRedirect(clickableText, itemNameRedirect, redirectColour);
+            return info;
+        }
+
+        InscryptionAPIPlugin.Logger.LogError($"Can't set rulebook redirect for {clickableText} because the StatIconInfo hasn't been added to the API yet.");
+        return info;
+    }
+    public static StatIconInfo SetUniqueRedirect(this StatIconInfo info, string clickableText, string uniqueRedirect, Color redirectColour)
+    {
+        StatIconManager.FullStatIcon full = StatIconManager.AllStatIcons.Find(x => x.Id == info.iconType);
+        if (full != null)
+        {
+            full.SetUniqueRedirect(clickableText, uniqueRedirect, redirectColour);
+            return info;
+        }
+
+        InscryptionAPIPlugin.Logger.LogError($"Can't set rulebook redirect for {clickableText} because the StatIconInfo hasn't been added to the API yet.");
+        return info;
+    }
+    #endregion
+
+    #region BoonData
+    public static BoonManager.FullBoon SetAbilityRedirect(this BoonManager.FullBoon fullBoon, string clickableText, Ability abilityRedirect, Color redirectColour)
+    {
+        fullBoon.RulebookDescriptionRedirects[clickableText] = new(PageRangeType.Abilities, redirectColour, abilityRedirect.ToString());
+        return fullBoon;
+    }
+    public static BoonManager.FullBoon SetStatIconRedirect(this BoonManager.FullBoon fullBoon, string clickableText, SpecialStatIcon statIconRedirect, Color redirectColour)
+    {
+        fullBoon.RulebookDescriptionRedirects[clickableText] = new(PageRangeType.StatIcons, redirectColour, statIconRedirect.ToString());
+        return fullBoon;
+    }
+    public static BoonManager.FullBoon SetBoonRedirect(this BoonManager.FullBoon fullBoon, string clickableText, BoonData.Type boonRedirect, Color redirectColour)
+    {
+        fullBoon.RulebookDescriptionRedirects[clickableText] = new(PageRangeType.Boons, redirectColour, boonRedirect.ToString());
+        return fullBoon;
+    }
+    public static BoonManager.FullBoon SetItemRedirect(this BoonManager.FullBoon fullBoon, string clickableText, string itemNameRedirect, Color redirectColour)
+    {
+        fullBoon.RulebookDescriptionRedirects[clickableText] = new(PageRangeType.Items, redirectColour, itemNameRedirect);
+        return fullBoon;
+    }
+    public static BoonManager.FullBoon SetUniqueRedirect(this BoonManager.FullBoon fullBoon, string clickableText, string uniqueRedirect, Color redirectColour)
+    {
+        fullBoon.RulebookDescriptionRedirects[clickableText] = new(PageRangeType.Unique, redirectColour, uniqueRedirect);
+        return fullBoon;
+    }
+
+    public static BoonData SetAbilityRedirect(this BoonData info, string clickableText, Ability abilityRedirect, Color redirectColour)
+    {
+        BoonManager.FullBoon full = BoonManager.AllFullBoons.Find(x => x.boon.type == info.type);
+        if (full != null)
+        {
+            full.SetAbilityRedirect(clickableText, abilityRedirect, redirectColour);
+            return info;
+        }
+
+        InscryptionAPIPlugin.Logger.LogError($"Can't set rulebook redirect for {clickableText} because the BoonData hasn't been added to the API yet.");
+        return info;
+    }
+    public static BoonData SetStatIconRedirect(this BoonData info, string clickableText, SpecialStatIcon statIconRedirect, Color redirectColour)
+    {
+        BoonManager.FullBoon full = BoonManager.AllFullBoons.Find(x => x.boon.type == info.type);
+        if (full != null)
+        {
+            full.SetStatIconRedirect(clickableText, statIconRedirect, redirectColour);
+            return info;
+        }
+
+        InscryptionAPIPlugin.Logger.LogError($"Can't set rulebook redirect for {clickableText} because the BoonData hasn't been added to the API yet.");
+        return info;
+    }
+    public static BoonData SetBoonRedirect(this BoonData info, string clickableText, BoonData.Type boonRedirect, Color redirectColour)
+    {
+        BoonManager.FullBoon full = BoonManager.AllFullBoons.Find(x => x.boon.type == info.type);
+        if (full != null)
+        {
+            full.SetBoonRedirect(clickableText, boonRedirect, redirectColour);
+            return info;
+        }
+
+        InscryptionAPIPlugin.Logger.LogError($"Can't set rulebook redirect for {clickableText} because the BoonData hasn't been added to the API yet.");
+        return info;
+    }
+    public static BoonData SetItemRedirect(this BoonData info, string clickableText, string itemNameRedirect, Color redirectColour)
+    {
+        BoonManager.FullBoon full = BoonManager.AllFullBoons.Find(x => x.boon.type == info.type);
+        if (full != null)
+        {
+            full.SetItemRedirect(clickableText, itemNameRedirect, redirectColour);
+            return info;
+        }
+
+        InscryptionAPIPlugin.Logger.LogError($"Can't set rulebook redirect for {clickableText} because the BoonData hasn't been added to the API yet.");
+        return info;
+    }
+    public static BoonData SetUniqueRedirect(this BoonData info, string clickableText, string uniqueRedirect, Color redirectColour)
+    {
+        BoonManager.FullBoon full = BoonManager.AllFullBoons.Find(x => x.boon.type == info.type);
+        if (full != null)
+        {
+            full.SetUniqueRedirect(clickableText, uniqueRedirect, redirectColour);
+            return info;
+        }
+
+        InscryptionAPIPlugin.Logger.LogError($"Can't set rulebook redirect for {clickableText} because the BoonData hasn't been added to the API yet.");
+        return info;
+    }
+    #endregion
+
+    #region ConsumableItemData
+    public static ConsumableItemManager.FullConsumableItemData SetAbilityRedirect(this ConsumableItemManager.FullConsumableItemData fullItem, string clickableText, Ability abilityRedirect, Color redirectColour)
+    {
+        fullItem.RulebookDescriptionRedirects[clickableText] = new(PageRangeType.Abilities, redirectColour, abilityRedirect.ToString());
+        return fullItem;
+    }
+    public static ConsumableItemManager.FullConsumableItemData SetStatIconRedirect(this ConsumableItemManager.FullConsumableItemData fullItem, string clickableText, SpecialStatIcon statIconRedirect, Color redirectColour)
+    {
+        fullItem.RulebookDescriptionRedirects[clickableText] = new(PageRangeType.StatIcons, redirectColour, statIconRedirect.ToString());
+        return fullItem;
+    }
+    public static ConsumableItemManager.FullConsumableItemData SetBoonRedirect(this ConsumableItemManager.FullConsumableItemData fullItem, string clickableText, BoonData.Type boonRedirect, Color redirectColour)
+    {
+        fullItem.RulebookDescriptionRedirects[clickableText] = new(PageRangeType.Boons, redirectColour, boonRedirect.ToString());
+        return fullItem;
+    }
+    public static ConsumableItemManager.FullConsumableItemData SetItemRedirect(this ConsumableItemManager.FullConsumableItemData fullItem, string clickableText, string itemNameRedirect, Color redirectColour)
+    {
+        fullItem.RulebookDescriptionRedirects[clickableText] = new(PageRangeType.Items, redirectColour, itemNameRedirect);
+        return fullItem;
+    }
+    public static ConsumableItemManager.FullConsumableItemData SetUniqueRedirect(this ConsumableItemManager.FullConsumableItemData fullItem, string clickableText, string uniqueRedirect, Color redirectColour)
+    {
+        fullItem.RulebookDescriptionRedirects[clickableText] = new(PageRangeType.Unique, redirectColour, uniqueRedirect);
+        return fullItem;
+    }
+
+    public static ConsumableItemData SetAbilityRedirect(this ConsumableItemData info, string clickableText, Ability abilityRedirect, Color redirectColour)
+    {
+        ConsumableItemManager.FullConsumableItemData full = ConsumableItemManager.allFullItemDatas.Find(x => x.itemData == info);
+        if (full != null)
+        {
+            full.SetAbilityRedirect(clickableText, abilityRedirect, redirectColour);
+            return info;
+        }
+
+        InscryptionAPIPlugin.Logger.LogError($"Can't set rulebook redirect for {clickableText} because the ConsumableItemData hasn't been added to the API yet.");
+        return info;
+    }
+    public static ConsumableItemData SetStatIconRedirect(this ConsumableItemData info, string clickableText, SpecialStatIcon statIconRedirect, Color redirectColour)
+    {
+        ConsumableItemManager.FullConsumableItemData full = ConsumableItemManager.allFullItemDatas.Find(x => x.itemData == info);
+        if (full != null)
+        {
+            full.SetStatIconRedirect(clickableText, statIconRedirect, redirectColour);
+            return info;
+        }
+
+        InscryptionAPIPlugin.Logger.LogError($"Can't set rulebook redirect for {clickableText} because the ConsumableItemData hasn't been added to the API yet.");
+        return info;
+    }
+    public static ConsumableItemData SetBoonRedirect(this ConsumableItemData info, string clickableText, BoonData.Type boonRedirect, Color redirectColour)
+    {
+        ConsumableItemManager.FullConsumableItemData full = ConsumableItemManager.allFullItemDatas.Find(x => x.itemData == info);
+        if (full != null)
+        {
+            full.SetBoonRedirect(clickableText, boonRedirect, redirectColour);
+            return info;
+        }
+
+        InscryptionAPIPlugin.Logger.LogError($"Can't set rulebook redirect for {clickableText} because the ConsumableItemData hasn't been added to the API yet.");
+        return info;
+    }
+    public static ConsumableItemData SetItemRedirect(this ConsumableItemData info, string clickableText, string itemNameRedirect, Color redirectColour)
+    {
+        ConsumableItemManager.FullConsumableItemData full = ConsumableItemManager.allFullItemDatas.Find(x => x.itemData == info);
+        if (full != null)
+        {
+            full.SetItemRedirect(clickableText, itemNameRedirect, redirectColour);
+            return info;
+        }
+
+        InscryptionAPIPlugin.Logger.LogError($"Can't set rulebook redirect for {clickableText} because the ConsumableItemData hasn't been added to the API yet.");
+        return info;
+    }
+    public static ConsumableItemData SetUniqueRedirect(this ConsumableItemData info, string clickableText, string uniqueRedirect, Color redirectColour)
+    {
+        ConsumableItemManager.FullConsumableItemData full = ConsumableItemManager.allFullItemDatas.Find(x => x.itemData == info);
+        if (full != null)
+        {
+            full.SetUniqueRedirect(clickableText, uniqueRedirect, redirectColour);
+            return info;
+        }
+
+        InscryptionAPIPlugin.Logger.LogError($"Can't set rulebook redirect for {clickableText} because the ConsumableItemData hasn't been added to the API yet.");
+        return info;
+    }
+    #endregion
+
+    #region RuleBookPageInfo
+    public static RuleBookPageInfo SetAbilityRedirect(this RuleBookPageInfo pageInfo, string clickableText, Ability abilityRedirect, Color redirectColour)
+    {
+        RuleBookPageInfoExt ext = CustomRedirectPages.Find(x => x.parentPageInfo == pageInfo);
+        if (ext == null)
+        {
+            ext = new(pageInfo, new());
+            CustomRedirectPages.Add(ext);
+        }
+        ext.RulebookDescriptionRedirects[clickableText] = new(PageRangeType.Abilities, redirectColour, abilityRedirect.ToString());
+        return pageInfo;
+    }
+    public static RuleBookPageInfo SetStatIconRedirect(this RuleBookPageInfo pageInfo, string clickableText, SpecialStatIcon statIconRedirect, Color redirectColour)
+    {
+        RuleBookPageInfoExt ext = CustomRedirectPages.Find(x => x.parentPageInfo == pageInfo);
+        if (ext == null)
+        {
+            ext = new(pageInfo, new());
+            CustomRedirectPages.Add(ext);
+        }
+        ext.RulebookDescriptionRedirects[clickableText] = new(PageRangeType.StatIcons, redirectColour, statIconRedirect.ToString());
+        return pageInfo;
+    }
+    public static RuleBookPageInfo SetBoonRedirect(this RuleBookPageInfo pageInfo, string clickableText, BoonData.Type boonRedirect, Color redirectColour)
+    {
+        RuleBookPageInfoExt ext = CustomRedirectPages.Find(x => x.parentPageInfo == pageInfo);
+        if (ext == null)
+        {
+            ext = new(pageInfo, new());
+            CustomRedirectPages.Add(ext);
+        }
+        ext.RulebookDescriptionRedirects[clickableText] = new(PageRangeType.Boons, redirectColour, boonRedirect.ToString());
+        return pageInfo;
+    }
+    public static RuleBookPageInfo SetItemRedirect(this RuleBookPageInfo pageInfo, string clickableText, string itemNameRedirect, Color redirectColour)
+    {
+        RuleBookPageInfoExt ext = CustomRedirectPages.Find(x => x.parentPageInfo == pageInfo);
+        if (ext == null)
+        {
+            ext = new(pageInfo, new());
+            CustomRedirectPages.Add(ext);
+        }
+        ext.RulebookDescriptionRedirects[clickableText] = new(PageRangeType.Items, redirectColour, itemNameRedirect);
+        return pageInfo;
+    }
+    public static RuleBookPageInfo SetUniqueRedirect(this RuleBookPageInfo pageInfo, string clickableText, string uniqueRedirect, Color redirectColour)
+    {
+        RuleBookPageInfoExt ext = CustomRedirectPages.Find(x => x.parentPageInfo == pageInfo);
+        if (ext == null)
+        {
+            ext = new(pageInfo, new());
+            CustomRedirectPages.Add(ext);
+        }
+        ext.RulebookDescriptionRedirects[clickableText] = new(PageRangeType.Unique, redirectColour, uniqueRedirect);
+        return pageInfo;
+    }
+    #endregion
+}

--- a/InscryptionAPI/Rulebook/RuleBookRedirectManager.cs
+++ b/InscryptionAPI/Rulebook/RuleBookRedirectManager.cs
@@ -50,14 +50,14 @@ public class RuleBookRedirectManager : Singleton<RuleBookRedirectManager>
         createdInteractableObjects.RemoveAll(x => x == null);
         createdInteractableObjects.ForEach(x => x.SetActive(false));
     }
-    public void UpdateActiveInteractables(TextMeshPro description, Dictionary<string, RuleBookManager.RedirectInfo> redirects)
+    public void UpdateActiveInteractables(TextMeshPro description, GameObject currentPageObj, Dictionary<string, RuleBookManager.RedirectInfo> redirects)
     {
-        InscryptionAPIPlugin.Logger.LogDebug("[UpdateActiveInteractables]");
+        InscryptionAPIPlugin.Logger.LogDebug($"[UpdateActiveInteractables]");
         Bounds pageBounds;
-        Bounds borderBounds = description.transform.parent.parent.Find("Border").GetComponent<SpriteRenderer>().bounds; // in world space
+        Bounds borderBounds = currentPageObj.transform.Find("Border").GetComponent<SpriteRenderer>().bounds; // in world space
         Vector3 pageBottomLeft;
         float zLength;
-        
+
         if (SaveManager.SaveFile.IsPart3)
         {
             pageBounds = currentTopPage.GetComponent<MeshRenderer>().bounds; // in world space

--- a/InscryptionAPI/Rulebook/RuleBookRedirectManager.cs
+++ b/InscryptionAPI/Rulebook/RuleBookRedirectManager.cs
@@ -1,0 +1,277 @@
+using DiskCardGame;
+using HarmonyLib;
+using InscryptionAPI.Card;
+using InscryptionAPI.Helpers.Extensions;
+using Steamworks;
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Text;
+using TMPro;
+using UnityEngine;
+
+namespace InscryptionAPI.RuleBook;
+
+// RuleBookRig/RigParent/RuleBook/Anim/PageFlipper/BookPage_1/Plane01
+// RuleBookRig_Part3/RigParent/Tablet/Anim
+// RulebookRig_Grimora/RigParent/RuleBook/Anim/PageFlipper/BookPage_1/Plane01
+// CardBattle_Magnificus/RuleBookRig_Magnificus/RigParent/RuleBook/Anim/PageFlipper/BookPage_1/Plane01
+
+/// <summary>
+/// Controls everything regarding the creation and positioning of page text redirects.
+/// </summary>
+public class RuleBookRedirectManager : Singleton<RuleBookRedirectManager>
+{
+    public readonly List<GameObject> createdInteractableObjects = new();
+    public readonly List<GameObject> currentActiveInteractables = new();
+    public int currentActivePageIndex = -1;
+
+    public Vector3 currentPageTopLeft;
+    public Vector3 descriptionTopLeft;
+    public float[] currentPageLengths;
+    public float[] descriptionLengths;
+
+    //public float currentPageRotation = 0f;
+
+    public Camera RuleBookCamera;
+    public Camera PixelCamera;
+
+    public Transform currentTopPage;
+
+    private void Start()
+    {
+        RuleBookCamera = RuleBookController.Instance.rigParent.GetComponentInChildren<Camera>();
+        PixelCamera = ViewManager.Instance.pixelCamera;
+    }
+
+    public void ClearActiveInteractables()
+    {
+        currentActiveInteractables.Clear();
+        createdInteractableObjects.RemoveAll(x => x == null);
+        createdInteractableObjects.ForEach(x => x.SetActive(false));
+    }
+    public void UpdateActiveInteractables(TextMeshPro description, Dictionary<string, RuleBookManager.RedirectInfo> redirects)
+    {
+        InscryptionAPIPlugin.Logger.LogDebug("[UpdateActiveInteractables]");
+        Bounds pageBounds;
+        Bounds borderBounds = description.transform.parent.parent.Find("Border").GetComponent<SpriteRenderer>().bounds; // in world space
+        Vector3 pageBottomLeft;
+        float zLength;
+        
+        if (SaveManager.SaveFile.IsPart3)
+        {
+            pageBounds = currentTopPage.GetComponent<MeshRenderer>().bounds; // in world space
+
+            // hard-set these due to to the pull-up animation messing up the coordinates
+            currentPageTopLeft = new(-1.129529f, 6.869874f, -5.502338f);
+            pageBottomLeft = new(-1.129529f, 5.6181f, -6.449201f);
+            descriptionTopLeft = new(borderBounds.max.x, borderBounds.max.y, (borderBounds.max.z + borderBounds.min.z) / 2f);
+
+            currentPageLengths = new float[2] { pageBounds.size.x - 0.4f, pageBounds.size.y - 0.4f };
+            descriptionLengths ??= new float[2] { borderBounds.size.y, (currentPageLengths[1] / currentPageLengths[0]) * borderBounds.size.y };
+        }
+        else
+        {
+            pageBounds = currentTopPage.GetComponent<SkinnedMeshRenderer>().sharedMesh.bounds; // in local space
+            descriptionTopLeft = new(borderBounds.min.x, borderBounds.max.y, (borderBounds.max.z + borderBounds.min.z) / 2f);
+
+            currentPageTopLeft = currentTopPage.transform.TransformPoint(pageBounds.max);
+            pageBottomLeft = currentTopPage.transform.TransformPoint(new(pageBounds.max.x, pageBounds.min.y, pageBounds.min.z));
+
+            currentPageLengths = new float[2] { 2.95f, 1.97f }; // hard set these since the rulebook pages aren't completely flat
+            descriptionLengths ??= new float[2] { borderBounds.size.x, (currentPageLengths[1] / currentPageLengths[0]) * borderBounds.size.x };
+        }
+        zLength = pageBottomLeft.z - currentPageTopLeft.z;
+        InscryptionAPIPlugin.Logger.LogDebug($"[DescTopLeft] {descriptionTopLeft.x} {descriptionTopLeft.y} {descriptionTopLeft.z}");
+        InscryptionAPIPlugin.Logger.LogDebug($"[PageTopLeft] {currentPageTopLeft.x} {currentPageTopLeft.y} {currentPageTopLeft.z}");
+        InscryptionAPIPlugin.Logger.LogDebug($"[PageBottomLeft] {pageBottomLeft.x} {pageBottomLeft.y} {pageBottomLeft.z} | {zLength}");
+
+        ClearActiveInteractables();
+        CreateInteractables(redirects, description, zLength);
+        currentActiveInteractables.ForEach(x => x.SetActive(true));
+    }
+
+    /// <summary>
+    /// Creates and positions the actual interactable object using the provided position and collider vectors.
+    /// The position is the world position relative to the rulebook.
+    /// Translates worldPosition to a screenpoint relative to the rulebook then back to world space relative to the pixel (player) camera.
+    /// </summary>
+    public void CreateInteractableObject(Vector3 worldPosition, Vector3 colliderSize, string keyText, RuleBookManager.RedirectInfo redirectInfo)
+    {
+        GameObject obj = createdInteractableObjects.Find(x => !currentActiveInteractables.Contains(x));
+        if (obj == null)
+        {
+            InscryptionAPIPlugin.Logger.LogDebug("Creating new page interactable");
+            obj = GameObject.CreatePrimitive(PrimitiveType.Cube);
+            obj.AddComponent<PageTextInteractable>().coll = obj.GetComponent<BoxCollider>();
+            createdInteractableObjects.Add(obj);
+        }
+
+        PageTextInteractable com = obj.GetComponent<PageTextInteractable>();
+        com.SetRedirect(redirectInfo.redirectType, redirectInfo.redirectPageId);
+        //com.relativeToRulebookPosition = worldPosition;
+
+        Vector3 newWorldPosition = PixelCamera.ScreenToWorldPoint(RuleBookCamera.WorldToScreenPoint(worldPosition));
+
+        InscryptionAPIPlugin.Logger.LogDebug($"[CreateInteractable] ({colliderSize.x} {colliderSize.y})");
+        InscryptionAPIPlugin.Logger.LogDebug($"[CreateInteractable] ({worldPosition.x} {worldPosition.y} {worldPosition.z}) ({newWorldPosition.x} {newWorldPosition.y} {newWorldPosition.z})");
+
+        obj.name = $"RuleBookPageInteractable ({keyText})";
+        obj.transform.SetParent(PixelCamera.transform);
+        obj.transform.position = newWorldPosition;
+        obj.transform.localScale = colliderSize;
+        obj.transform.localRotation = Quaternion.identity;
+        currentActiveInteractables.Add(obj);
+    }
+
+    /// <summary>
+    /// Creates interactable objects using word indeces to determine the positioning and size of each interactable.
+    /// Interactables will be the same size of the entire key phrase to minimise object creation.
+    /// If the key text wraps onto a different line, an additional interactable will be created for the new line.
+    /// </summary>
+    private void CreateInteractables(Dictionary<string, RuleBookManager.RedirectInfo> redirectInfos, TextMeshPro description, float zLength)
+    {
+        float textHeight = -1;
+        float textScalar = description.transform.localScale.x;
+        foreach (string keyText in redirectInfos.Keys)
+        {
+            foreach (List<int> indeces in GetWordIndeces(description.textInfo, keyText))
+            {
+                int currentLine = -1;
+                List<Vector3> colliderSizes = new();
+                List<Vector3> colliderPositions = new();
+                Vector3 bottomLeft = Vector3.zero, topRight = Vector3.zero;
+
+                foreach (int index in indeces) // for each word in the entire phrase
+                {
+                    TMP_WordInfo word = description.textInfo.wordInfo[index];
+                    List<TMP_CharacterInfo> charsInWord = description.textInfo.characterInfo.ToList().GetRange(word.firstCharacterIndex, word.lastCharacterIndex - word.firstCharacterIndex + 1);
+                    //Debug.Log($"Index [{index}] [{word.GetWord()}] Count: {charsInWord.Count} [{charsInWord[0].character} {charsInWord.Last().character}]");
+
+                    if (textHeight == -1) textHeight = charsInWord[0].topLeft.y - charsInWord[0].bottomLeft.y;
+
+                    while (charsInWord.Count > 0)
+                    {
+                        if (currentLine == -1)
+                        {
+                            currentLine = charsInWord[0].lineNumber;
+                            bottomLeft = charsInWord[0].bottomLeft;
+                        }
+                        List<TMP_CharacterInfo> charsOnLine = charsInWord.FindAll(x => x.lineNumber == currentLine);
+
+                        charsInWord.RemoveAll(charsOnLine.Contains);
+                        if (charsOnLine.Count > 0)
+                        {
+                            topRight = charsOnLine.Last().topRight;
+                        }
+
+                        // if there are still characters remaining then that means there's a new line
+                        // so create collider data using current info then clear info
+                        if (charsInWord.Count > 0)
+                        {
+                            //Debug.Log("Start new line");
+                            CreateColliderSizeAndPosition(description.transform, textHeight, zLength, bottomLeft, topRight, colliderSizes, colliderPositions);
+                            currentLine = -1;
+                        }
+                    }
+                }
+                if (currentLine != -1)
+                {
+                    //Debug.Log("Finalise line");
+                    CreateColliderSizeAndPosition(description.transform, textHeight, zLength, bottomLeft, topRight, colliderSizes, colliderPositions);
+                }
+
+                for (int i = 0; i < colliderSizes.Count; i++)
+                {
+                    Vector3 size = colliderSizes[i];
+                    Vector3 position = colliderPositions[i];
+                    CreateInteractableObject(
+                        colliderPositions[i],
+                        colliderSizes[i] * textScalar * textScalar,
+                        keyText,
+                        redirectInfos[keyText]);
+                }
+            }
+        }
+    }
+
+    /// <summary>
+    /// Gets the indeces of every instance of every word in the key.
+    /// </summary>
+    public static IEnumerable<List<int>> GetWordIndeces(TMP_TextInfo textInfo, string key)
+    {
+        string[] splitKey = key.Split();
+        TMP_WordInfo[] wordInfo = textInfo.wordInfo;
+        List<List<int>> indeces = new();
+
+        //Debug.Log($"[GetWordIndeces] {splitKey.Length} F: {splitKey.First()} L: {splitKey.Last()}");
+        for (int i = 0; i < wordInfo.Length; i++)
+        {
+            if (wordInfo[i].characterCount == 0)
+                continue;
+
+            if (wordInfo[i].GetWord() == splitKey[0])
+            {
+                int k = -1;
+                List<int> keyIndeces = new() { i };
+                for (int j = 1; j < splitKey.Length; j++)
+                {
+                    k = j;
+                    if (wordInfo[i + k].characterCount == 0)
+                        continue;
+
+                    if (wordInfo[i + k].GetWord() == splitKey[j])
+                    {
+                        //Debug.Log($"NextWord: {wordInfo[k].GetWord()}");
+                        keyIndeces.Add(i + k);
+                    }
+                }
+                if (k != -1) i += k;
+
+                indeces.Add(keyIndeces);
+            }
+        }
+        return indeces;
+    }
+    private void CreateColliderSizeAndPosition(Transform textMesh, float sizeY, float zLength, Vector3 bottomLeft, Vector3 topRight, List<Vector3> colliderSizes, List<Vector3> colliderPositions)
+    {
+        Vector3 bottomLeftWorld = textMesh.TransformPoint(bottomLeft);
+        Vector3 topRightWorld = textMesh.TransformPoint(topRight);
+        Vector3 wordPos = new(
+            (topRightWorld.x + bottomLeftWorld.x) / 2f,
+            (topRightWorld.y + bottomLeftWorld.y) / 2f,
+            bottomLeftWorld.z + 0.01f
+            );
+
+        float correctedXProportion;
+        float correctedX;
+        float correctedYProportion;
+        float zCorrection; // zCorrection stuff is completely made up nonsense
+        float correctedY;
+        Vector3 correctedPos;
+
+        if (SaveManager.SaveFile.IsPart3)
+        {
+            correctedXProportion = (descriptionTopLeft.y - wordPos.y) / descriptionLengths[0];
+            correctedX = currentPageTopLeft.x + (currentPageLengths[0] * correctedXProportion);
+
+            correctedYProportion = (descriptionTopLeft.x - wordPos.x) / descriptionLengths[1];
+            zCorrection = zLength * correctedYProportion;
+            correctedY = currentPageTopLeft.y - (currentPageLengths[1] * correctedYProportion) - (zCorrection * correctedYProportion);
+        }
+        else
+        {
+            correctedXProportion = (wordPos.x - descriptionTopLeft.x) / descriptionLengths[0];
+            correctedX = currentPageTopLeft.x + (currentPageLengths[0] * correctedXProportion);
+
+            correctedYProportion = (descriptionTopLeft.y - wordPos.y) / descriptionLengths[1];
+            zCorrection = zLength * correctedYProportion;
+            correctedY = currentPageTopLeft.y - (currentPageLengths[1] * correctedYProportion) - (zCorrection * correctedYProportion);
+            
+        }
+        correctedPos = new(correctedX, correctedY, currentPageTopLeft.z + (zCorrection + zCorrection * correctedYProportion));
+        Debug.Log($"[Corrected] ({correctedPos.x} {correctedPos.y} {correctedPos.z}) | {correctedXProportion} {correctedYProportion}");
+        colliderPositions.Add(correctedPos);
+        colliderSizes.Add(new((topRight.x - bottomLeft.x) + sizeY / 2f, sizeY * 3f / 2f, 0.001f)); // add padding to compensate for inaccurate positioning
+    }
+}

--- a/InscryptionAPI/Rulebook/RulebookRedirectPatches.cs
+++ b/InscryptionAPI/Rulebook/RulebookRedirectPatches.cs
@@ -1,0 +1,117 @@
+using DiskCardGame;
+using HarmonyLib;
+using InscryptionAPI.Card;
+using InscryptionAPI.Helpers.Extensions;
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Reflection;
+using System.Text;
+using TMPro;
+using UnityEngine;
+
+namespace InscryptionAPI.RuleBook;
+
+/* Outlining my manifesto here
+ * So we want to create interactable objects that correspond to the dimensions and position of words in the rulebook
+ * because god hates me, this isn't as easy as attaching objects to the book and then sizing them
+ * rather what we want to do is:
+ * get the current top page
+ * get the position and dimensions of words we want to create interactable icons for
+ * convert the world coordinates to the viewport of the rulebook camera
+ * convert that viewport to world coordinates relative to the main camera
+ * create interactables at the new world coords, parented to the main camera
+ * destroy interactables when unneeded*/
+
+// we want modders to be able to set multiple redirects that can go to different types of pages
+// eg: abilities, stat icons, boons, items
+[HarmonyPatch]
+public static class RulebookRedirectPatches
+{
+    [HarmonyPostfix, HarmonyPatch(typeof(RuleBookController), nameof(RuleBookController.Start))]
+    private static void CreateRedirectManager(RuleBookController __instance)
+    {
+        if (RuleBookRedirectManager.m_Instance == null)
+        {
+            __instance.gameObject.AddComponent<RuleBookRedirectManager>();
+        }
+    }
+
+    [HarmonyPrefix, HarmonyPatch(typeof(RuleBookController), nameof(RuleBookController.SetShown))]
+    private static void ResetInteractables(RuleBookController __instance, bool shown)
+    {
+        if (__instance.rigParent.activeSelf == shown)
+            return;
+
+        RuleBookRedirectManager.Instance.ClearActiveInteractables();
+    }
+
+    [HarmonyPostfix, HarmonyPatch(typeof(RulebookPageFlipper), nameof(RulebookPageFlipper.ShowFlipToPage))]
+    private static IEnumerator ResetTrueTopIndex(IEnumerator enumerator, int pageIndex)
+    {
+        rulebookShowFlipIndex = pageIndex;
+        yield return enumerator;
+        rulebookShowFlipIndex = -1;
+    }
+    public static int rulebookShowFlipIndex = -1;
+
+    /*[HarmonyPostfix, HarmonyPatch(typeof(RulebookPageFlipper), nameof(RulebookPageFlipper.RandomRotationAdjustment))]
+    private static void RetrieveRandomRotation(Transform page)
+    {
+        if (page == RuleBookRedirectManager.Instance.currentTopPage.parent)
+        {
+            RuleBookRedirectManager.Instance.currentPageRotation = page.localEulerAngles.y;
+        }
+    }*/
+
+    [HarmonyPrefix, HarmonyPatch(typeof(RulebookPageFlipper), nameof(RulebookPageFlipper.RenderPages))]
+    private static bool RetrieveRuleBookTopPage(Transform topPage)
+    {
+        RuleBookRedirectManager.Instance.currentTopPage = topPage.Find("Plane01");
+        return true;
+    }
+
+    [HarmonyPostfix, HarmonyPatch(typeof(PageFlipper), nameof(PageFlipper.LoadPageContent))]
+    private static void AddInteractablesToTopPage(PageFlipper __instance, PageContentLoader loader, int index)
+    {
+        if (__instance.currentPageIndex != RuleBookRedirectManager.Instance.currentActivePageIndex)
+            RuleBookRedirectManager.Instance.ClearActiveInteractables();
+
+        if (index != __instance.currentPageIndex)
+            return;
+
+        RuleBookPageInfo pageInfo = __instance.PageData[__instance.currentPageIndex];
+        RuleBookManager.RuleBookPageInfoExt fullInfo = RuleBookManager.ConstructedPagesWithRedirects.Find(x => x.parentPageInfo == pageInfo);
+        if (fullInfo == null || fullInfo.RulebookDescriptionRedirects.Count == 0)
+            return;
+
+        if (__instance is TabletPageFlipper && RuleBookRedirectManager.Instance.currentTopPage == null)
+        {
+            RuleBookRedirectManager.Instance.currentTopPage = RuleBookRedirectManager.Instance.currentTopPage ??= Singleton<RuleBookController>.Instance.rigParent.transform.Find("Tablet").Find("Anim").transform;
+        }
+        else if (__instance is RulebookPageFlipper && rulebookShowFlipIndex != -1 && index != rulebookShowFlipIndex)
+        {
+            return; // account for ShowFlipToPage moving the currentIndex back 3     
+        }
+
+        TextMeshPro descriptionMesh;
+        RuleBookPage component = loader.currentPageObj.GetComponent<RuleBookPage>();
+        if (component is AbilityPage ab)
+            descriptionMesh = ab.mainAbilityGroup.descriptionTextMesh;
+        else if (component is StatIconPage icon)
+            descriptionMesh = icon.descriptionTextMesh;
+        else if (component is BoonPage boon)
+            descriptionMesh = boon.descriptionTextMesh;
+        else if (component is ItemPage item)
+            descriptionMesh = item.descriptionTextMesh;
+        else
+            descriptionMesh = loader.currentPageObj.GetComponentInChildren<TextMeshPro>();
+
+        if (descriptionMesh != null)
+        {
+            descriptionMesh.ForceMeshUpdate();
+            RuleBookRedirectManager.Instance.UpdateActiveInteractables(descriptionMesh, fullInfo.RulebookDescriptionRedirects);
+        }
+        RuleBookRedirectManager.Instance.currentActivePageIndex = __instance.currentPageIndex;
+    }
+}

--- a/InscryptionAPI/Rulebook/RulebookRedirectPatches.cs
+++ b/InscryptionAPI/Rulebook/RulebookRedirectPatches.cs
@@ -53,16 +53,8 @@ public static class RulebookRedirectPatches
         yield return enumerator;
         rulebookShowFlipIndex = -1;
     }
-    public static int rulebookShowFlipIndex = -1;
 
-    /*[HarmonyPostfix, HarmonyPatch(typeof(RulebookPageFlipper), nameof(RulebookPageFlipper.RandomRotationAdjustment))]
-    private static void RetrieveRandomRotation(Transform page)
-    {
-        if (page == RuleBookRedirectManager.Instance.currentTopPage.parent)
-        {
-            RuleBookRedirectManager.Instance.currentPageRotation = page.localEulerAngles.y;
-        }
-    }*/
+    public static int rulebookShowFlipIndex = -1;
 
     [HarmonyPrefix, HarmonyPatch(typeof(RulebookPageFlipper), nameof(RulebookPageFlipper.RenderPages))]
     private static bool RetrieveRuleBookTopPage(Transform topPage)
@@ -105,12 +97,12 @@ public static class RulebookRedirectPatches
         else if (component is ItemPage item)
             descriptionMesh = item.descriptionTextMesh;
         else
-            descriptionMesh = loader.currentPageObj.GetComponentInChildren<TextMeshPro>();
+            descriptionMesh = loader.currentPageObj.transform.Find("Description").GetComponent<TextMeshPro>();
 
         if (descriptionMesh != null)
         {
             descriptionMesh.ForceMeshUpdate();
-            RuleBookRedirectManager.Instance.UpdateActiveInteractables(descriptionMesh, fullInfo.RulebookDescriptionRedirects);
+            RuleBookRedirectManager.Instance.UpdateActiveInteractables(descriptionMesh, loader.currentPageObj, fullInfo.RulebookDescriptionRedirects);
         }
         RuleBookRedirectManager.Instance.currentActivePageIndex = __instance.currentPageIndex;
     }

--- a/InscryptionAPI/Slots/SlotModificationExtensions.cs
+++ b/InscryptionAPI/Slots/SlotModificationExtensions.cs
@@ -47,6 +47,42 @@ public static class SlotModificationExtensions
         }
         return mod;
     }
+    public static ModificationType SetRulebookP03Sprite(this ModificationType mod, Texture2D spriteTexture)
+    {
+        Info info = AllSlotModifications.InfoByID(mod);
+        if (info != null)
+        {
+            info.P03RulebookSprite = spriteTexture.ConvertTexture();
+        }
+        return mod;
+    }
+    public static ModificationType SetRulebookGrimoraSprite(this ModificationType mod, Texture2D spriteTexture)
+    {
+        Info info = AllSlotModifications.InfoByID(mod);
+        if (info != null)
+        {
+            info.GrimoraRulebookSprite = spriteTexture.ConvertTexture();
+        }
+        return mod;
+    }
+    public static ModificationType SetRulebookMagnificusSprite(this ModificationType mod, Texture2D spriteTexture)
+    {
+        Info info = AllSlotModifications.InfoByID(mod);
+        if (info != null)
+        {
+            info.MagnificusRulebookSprite = spriteTexture.ConvertTexture();
+        }
+        return mod;
+    }
+    public static ModificationType SetSharedRulebook(this ModificationType mod, ModificationType sharedRulebookType)
+    {
+        Info info = AllSlotModifications.InfoByID(mod);
+        if (info != null)
+        {
+            info.SharedRulebook = sharedRulebookType;
+        }
+        return mod;
+    }
 
     /// <summary>
     /// Assigns a new slot modification to a slot.
@@ -60,18 +96,18 @@ public static class SlotModificationExtensions
 
         Info defn = AllModificationInfos.InfoByID(modType);
         SlotModificationInteractable interactable = slot.GetComponent<SlotModificationInteractable>();
-        if (defn.RulebookName != null)
-        {
-            interactable ??= slot.gameObject.AddComponent<SlotModificationInteractable>();
-            interactable.AssignSlotModification(modType, slot);
-        }
-        else
+        if (defn == null || modType == ModificationType.NoModification || (defn.SharedRulebook == ModificationType.NoModification && string.IsNullOrEmpty(defn.RulebookName)))
         {
             interactable?.SetEnabled(false);
         }
+        else
+        {
+            interactable ??= slot.gameObject.AddComponent<SlotModificationInteractable>();
+            interactable.AssignSlotModification(defn.SharedRulebook != ModificationType.NoModification ? defn.SharedRulebook : modType, slot);
+        }
 
         // Set the ability behaviour
-        var oldSlotModification = slot.GetComponent<SlotModificationBehaviour>();
+        SlotModificationBehaviour oldSlotModification = slot.GetComponent<SlotModificationBehaviour>();
         if (oldSlotModification != null)
         {
             yield return oldSlotModification.Cleanup(modType);

--- a/InscryptionAPI/Slots/SlotModificationInteractable.cs
+++ b/InscryptionAPI/Slots/SlotModificationInteractable.cs
@@ -22,6 +22,6 @@ public class SlotModificationInteractable : AlternateInputInteractable
     public override void OnAlternateSelectStarted()
     {
         //InscryptionAPIPlugin.Logger.LogDebug($"Open to slot mod page: [{ModType}] on slot [{slot}]");
-        RuleBookController.Instance.OpenToItemPage(SlotModificationManager.SLOT_PAGEID + (int)ModType, true);
+        RuleBookController.Instance.OpenToItemPage(SlotModificationManager.SLOT_PAGEID + (int)ModType, false);
     }
 }

--- a/InscryptionAPI/Slots/SlotModificationManager.cs
+++ b/InscryptionAPI/Slots/SlotModificationManager.cs
@@ -527,7 +527,7 @@ public class SlotModificationManager : MonoBehaviour
         //InscryptionAPIPlugin.Logger.LogInfo($"In rulebook patch: I see {AllModificationInfos.Count}");
         if (AllModificationInfos.Count > 0)
         {
-            List<Info> infos = AllModificationInfos.Where(x => SlotModShouldBeAdded(x, (ModificationMetaCategory)metaCategory)).ToList();
+            List<Info> infos = AllModificationInfos.Where(x => RuleBookManager.SlotModShouldBeAdded(x, (ModificationMetaCategory)metaCategory)).ToList();
             if (infos.Count == 0)
                 return;
 
@@ -551,8 +551,6 @@ public class SlotModificationManager : MonoBehaviour
             }
         }
     }
-
-    public static bool SlotModShouldBeAdded(Info info, ModificationMetaCategory category) => info.RulebookName != null && info.MetaCategories.Contains(category);
 
     public const string SLOT_PAGEID = "SlotModification_";
 

--- a/InscryptionAPI/TalkingCards/Create/TalkingCardCreator.cs
+++ b/InscryptionAPI/TalkingCards/Create/TalkingCardCreator.cs
@@ -49,7 +49,7 @@ public static class TalkingCardCreator
         TalkingAbilities.Remove(cardName);
     }
 
-    internal static void New(FaceData faceData, SpecialTriggeredAbility talkAbility)
+    internal static void New(FaceData faceData, SpecialTriggeredAbility talkAbility, bool diskTalkingCard)
     {
         if (AnimatedPortraits.ContainsKey(faceData.CardName))
         {
@@ -77,7 +77,7 @@ public static class TalkingCardCreator
         card.AddSpecialAbilities(talkAbility);
 
         // Special behaviour for the talking cards
-        if (card.temple == CardTemple.Tech)
+        if (diskTalkingCard)
         {
             card.AddAppearances(CardAppearanceBehaviour.Appearance.DynamicPortrait);
             foreach (var rend in card.AnimatedPortrait.GetComponentsInChildren<SpriteRenderer>())
@@ -96,6 +96,10 @@ public static class TalkingCardCreator
         {
             card.AddAppearances(CardAppearanceBehaviour.Appearance.AnimatedPortrait);
         }
+    }
+    internal static void New(FaceData faceData, SpecialTriggeredAbility talkAbility)
+    {
+        New(faceData, talkAbility, CardHelpers.Get(faceData.CardName)?.temple == CardTemple.Tech);
     }
 
     private static void RecursiveSetLayer(GameObject obj, string layerName)

--- a/InscryptionAPI/TalkingCards/CustomPaperTalkingCard.cs
+++ b/InscryptionAPI/TalkingCards/CustomPaperTalkingCard.cs
@@ -26,3 +26,20 @@ public abstract class CustomPaperTalkingCard : PaperTalkingCard, ITalkingCard
         yield break;
     }
 }
+
+public abstract class CustomDiskTalkingCard : DiskTalkingCard, ITalkingCard
+{
+    public override DialogueEvent.Speaker SpeakerType => DialogueEvent.Speaker.Stoat;
+    public abstract string CardName { get; }
+    public abstract List<EmotionData> Emotions { get; }
+    public abstract FaceInfo FaceInfo { get; }
+    public abstract SpecialTriggeredAbility DialogueAbility { get; }
+
+    public override string OnDrawnFallbackDialogueId => OnDrawnDialogueId;
+    public override IEnumerator OnShownForCardSelect(bool forPositiveEffect)
+    {
+        yield return new WaitForEndOfFrame();
+        yield return base.OnShownForCardSelect(forPositiveEffect);
+        yield break;
+    }
+}

--- a/InscryptionAPI/TalkingCards/Helpers/CardHelpers.cs
+++ b/InscryptionAPI/TalkingCards/Helpers/CardHelpers.cs
@@ -1,4 +1,5 @@
 using DiskCardGame;
+using InscryptionAPI.Card;
 
 #nullable enable
 namespace InscryptionAPI.TalkingCards.Helpers;
@@ -7,6 +8,7 @@ internal class CardHelpers
 {
     public static CardInfo? Get(string name)
     {
+        CardManager.SyncCardList();
         CardInfo? card;
         try
         {

--- a/InscryptionAPI/TalkingCards/TalkingCardManager.cs
+++ b/InscryptionAPI/TalkingCards/TalkingCardManager.cs
@@ -31,6 +31,22 @@ public static class TalkingCardManager
     }
 
     /// <summary>
+    /// Create a talking card for Act 3.
+    /// </summary>
+    public static void NewDisk<T>() where T : ITalkingCard, new()
+    {
+        ITalkingCard x = new T();
+
+        FaceData faceData = new(
+                x.CardName,
+                x.Emotions,
+                x.FaceInfo
+            );
+
+        TalkingCardCreator.New(faceData, x.DialogueAbility, true);
+    }
+
+    /// <summary>
     /// Create a talking card from a FaceData instance through this API.
     /// </summary>
     /// <param name="faceData">Your character's face data.</param>
@@ -40,7 +56,16 @@ public static class TalkingCardManager
         if (faceData?.CardName == null) return;
         TalkingCardCreator.New(faceData, ability);
     }
-    
+
+    /// <summary>
+    /// Create a talking card for Act 3 from a FaceData instance.
+    /// </summary>
+    public static void CreateDisk(FaceData faceData, SpecialTriggeredAbility ability, bool diskTalkingCard)
+    {
+        if (faceData?.CardName == null) return;
+        TalkingCardCreator.New(faceData, ability, diskTalkingCard);
+    }
+
     /// <summary>
     /// Remove a talking card from a FaceData instance through this API.
     /// </summary>

--- a/docs/wiki/items.md
+++ b/docs/wiki/items.md
@@ -51,3 +51,5 @@ ConsumableItemManager.New(Plugin.PluginGuid, "Custom Item", "Does a thing!", tex
 		        .SetDescription(learnText)
 		        .SetAct1();
 ```
+
+If you want your item to appear in the rulebook in multiple Acts, use the extension `AddExtraRulebookCategories` on the returned ConsumableItemData.

--- a/docs/wiki/redirect.md
+++ b/docs/wiki/redirect.md
@@ -1,0 +1,43 @@
+# Adding Text Redirects
+Made of Stone is a vanilla ability that negates the effects of Stinky and Touch of Death.
+This is an example of an ability whose behaviour directly relates to other abilities, and in your modding journey you may end up making something similar, be it an ability or stat icon or other.
+
+In these situations you might want to make it easy for players to easily see what these other abilities do, rather than making them flip through the entire rulebook just to recall their effect.
+
+Enter the API.
+
+When making an ability, stat icon, boon, item, or custom rulebook page, you can mark certain words or phrases in their description to be turned into page redirects.
+
+These function similarly to links you will see on the internet; the marked word(s) will be coloured and underlined, and when right-clicked they will take you to a different rulebook page.
+
+For example, if you wanted Made of Stone to link to Stinky and Touch of Death, you would do the following:
+
+```c#
+AbilityInfo info = AbilitiesUtil.GetInfo(Ability.MadeOfStone);
+
+// note that the provided string is CASE-SENSITIVE - if we passed in "touch of death" instead, it wouldn't function
+info.SetAbilityRedirect("Touch of Death", Ability.Deathtouch, GameColors.Instance.red);
+info.SetAbilityRedirect("Stinky", Ability.DebuffEnemy, GameColors.Instance.orange);
+```
+
+Now when you open the page for Made of Stone, the word 'Stinky' will be orange and redirect you to Stinky's page, and the words 'Touch of Death' will be red and redirect you to Touch of Death's page.
+
+Redirects can be also be set for stat icons, items, and boons:
+
+```c#
+AbilityInfo info = AbilitiesUtil.GetInfo(Ability.MadeOfStone);
+info.SetBoonRedirect("effects", BoonData.Type.DoubleDraw, GameColors.Instance.gray);
+
+StatIconInfo stat = StatIconManager.AllStatIconInfos.Find(x => x.iconType == SpecialStatIcon.Ants);
+stat.SetItemRedirect("represented", "Harpy Fan", GameColors.Instance.brightLimeGreen);
+```
+
+If you want a redirect to point to a custom rulebook page, you can use SetUniqueRedirect, and instead of an Ability or Boon.Type you provide a string corresponding to the custom rulebook page's `pageId`.
+
+## Text Colours
+As you likely noticed, each redirect takes a Color as an argument.
+This, expectedly, changes the text's colour to help indicate that a certain text is clickable.
+In the above examples, only colours that come with Inscryption are used, but you can create and pass in custom colours as well.
+
+It's important to note that not all colours will function as expected, particularly in Act 1 due to its lighting.
+The range of atypical colours hasn't been fully tested in every act, but do note that Act 1 will render blue text as green, and white and yellow text will be transparent in normal lighting.

--- a/docs/wiki/redirect.md
+++ b/docs/wiki/redirect.md
@@ -22,7 +22,7 @@ info.SetAbilityRedirect("Stinky", Ability.DebuffEnemy, GameColors.Instance.orang
 
 Now when you open the page for Made of Stone, the word 'Stinky' will be orange and redirect you to Stinky's page, and the words 'Touch of Death' will be red and redirect you to Touch of Death's page.
 
-Redirects can be also be set for stat icons, items, and boons:
+Redirects can be also be set for stat icons, items, boons, and slot modifications:
 
 ```c#
 AbilityInfo info = AbilitiesUtil.GetInfo(Ability.MadeOfStone);

--- a/docs/wiki/rulebook.md
+++ b/docs/wiki/rulebook.md
@@ -1,129 +1,18 @@
 ## The Rulebook
-The Rulebook is a powerful tool for the player during the 3D Acts.
-Every ability, stat icon, boon and item that they can encounter during a certain Act will have an entry in it, providing a name and description of what it does.
+The Rulebook is a vital tool for the player while playing outside of Act 2.
 
-These entries are act-specific, and custom abilities and the like can be marked to only appear in a certain Act or Acts* using their specific AbilityMetaCategory field.
+Every ability, stat icon, boon, and item that can appear in the current Act will have an entry in the book, providing information on what each one does.
+Custom abilities and such will appear in the rulebook if marked to do so in their `metaCategories` field*.
 
-In most cases, this is the end of a modder's consideration Rulebook. If you're making a mod for Act 3, custom sigils should appear in the Act 3 Rulebook and nowhere else.
-If you don't want a stat icon to appear in any Rulebook for one reason or another, you simply leave its AbilityMetaCategories field empty.
-Custom content that appears in the Rulebook will appear in the order they were loaded into the game by the API, content that doesn't won't.
+For most situations, this will be the extent of your modding experience with the rulebook; if you want an ability to appear in Act 1, you give it the appropriate AbilityMetaCategoy.
+If you don't want a stat icon to appear in the rulebook at all, you leave `metaCategories` empty.
+
+However, there are some instances where you'll want to modify the rulebook even further, such as adding custom pages or even a whole new section to the rulebook.
+In these cases, the API has you covered.
 
 However, there may arise cases where this is insufficient for your needs.
 Maybe you want an ability to always appear at the beginning of the Rulebook for some reason, or you want to add a whole new section to the Rulebook.
 The former case can be easily handled with a simple patch to RuleBookInfo.ConstructPageData, but the latter can get fairly complicated.
 In either case, you can use the API's RuleBookManager to make this process simpler.
 
-\* *Items and Boons can only be marked to appear in a single Act.*
-
-## Adding Custom Sections
-Creating a custom rulebook section/range is a bit different than creating other things like abilities.
-Custom sections don't require a Type reference to a custom class, though it's still good practice to create a class to keep things organised.
-
-Simple call RuleBookManager.New() with the needed arguments and you're good to go.
-
-```c#
-RuleBookManager.New(
-    MyPluginGuid, // a unique identifier for your mod
-    PageRangeType.Boons, // the PageRangeType we want to inherit our page style from
-    "Mod Tribes", // the subsection name that appears at the end of the header
-    GetInsertPosition, // a function that determines where in the Rulebook to insert our custom section
-    CreatePages, // the function to create the pages that will be in our custom section
-    headerPrefix: null, // optional argument, if left null one will be created for you
-    getStartingNumberFunc: GetStartingNumber, // optional argument, if left null the starting number will be 1
-    fillPageAction: FillPage // also optional, but if you want to display custom names, descriptions, etc you will need to set this
-    );
-```
-
-This will return a FullRuleBookRangeInfo object representing your custom section.
-
-Note how you can pass in STATIC methods as arguments when creating your custom rulebook range.
-
-
-```c#
-// note that the return value and parameters MUST match the parameters and return value of the Func
-private static int GetInsertPosition(PageRangeInfo pageRangeInfo, List<RuleBookPageInfo> pages)
-{
-    return pages.FindLastIndex(rbi => rbi.pagePrefab == pageRangeInfo.rangePrefab) + 1;
-}
-
-private static List<RuleBookPageInfo> CreatePages(RuleBookInfo instance, PageRangeInfo currentRange, AbilityMetaCategory metaCategory)
-{
-    // in this example, we're adding a rulebook section for custom Tribes
-    // foreach custom tribe that exists, we create a rulebook page then set the pageId to the tribe enum so we can use it later
-    List<TribeManager.TribeInfo> allTribes = TribeManager.NewTribes.ToList();
-    List<RuleBookPageInfo> retval = new();
-    foreach (var tribe in allTribes)
-    {
-        RuleBookPageInfo page = new();
-        page.pageId = tribe.tribe.ToString();
-        retval.Add(page);
-    }
-    return retval;
-}
-
-private static int GetStartingNumber(List<RuleBookPageInfo> addedPages)
-{
-    return (int)Tribe.NUM_TRIBES; // since we're doing mod Tribes only, we start after custom Tribes (pretend we have a separate section for those)
-}
-
-private static void FillPage(RuleBookPage page, string pageId, object[] otherArgs)
-{
-    if (page is BoonPage boonPage && int.TryParse(pageId, out int id))
-    {
-        TribeManager.TribeInfo tribe = TribeManager.NewTribes.FirstOrDefault(x => x.tribe == (Tribe)id);
-        if (tribe != null)
-        {
-            boonPage.nameTextMesh.text = Localization.Translate(tribe.name.ToLowerInvariant().Replace("tribe", ""));
-            boonPage.descriptionTextMesh.text = "";
-            boonPage.iconRenderer.material.mainTexture = boonPage.iconRenderer2.material.mainTexture = tribe.icon.texture;
-        }
-    }
-}
-```
-
-## Useful Information on RuleBookPages
-When filling the content of your custom pages, it's important to understand the page style and what fields you'll have access to.
-
-When your custom section's FillPage() method is called, only certain parts of the current RuleBookPageInfo will be provided to you.
-If you plan on using information beyond the pageId when filling your pages, you need to know the order of objects in the array.
-
-### AbilityPage
-Ability icon texture is placed on the left of the page
-
-otherArgs: headerText, ability, fillerAbilityIds
-
-Class Fields:
-- AbilityPageContent *mainAbilityGroup*
-
-### StatIconPage
-Stat Icon texture is placed on the left of the icon's name
-
-otherArgs: headerText
-
-Class Fields:
-- Renderer *iconRenderer*
-- TextMeshPro *nameTextMesh*
-- TextMeshPro *descriptionTextMesh*
-
-### BoonPage
-Boon texture is placed on the left and right of the page
-
-otherArgs: headerText, boon
-
-Class Fields:
-- Renderer *iconRenderer*
-- Renderer *iconRenderer2*
-- TextMeshPro *nameTextMesh*
-- TextMeshPro *descriptionTextMesh*
-
-### ItemPage
-Item's rulebookSprite is placed on the left of the page
-
-otherArgs: headerText
-
-Class Fields:
-- Renderer *iconRenderer*
-- TextMeshPro *nameTextMesh*
-- TextMeshPro *descriptionTextMesh*
-- Transform *itemModelParent*
-- GameObject *itemModel*
+\* *Items and Boons can be made to appear in multiple Acts or outside Act 1 by modifying their associated Full(...)Info.*

--- a/docs/wiki/rulebook_sections.md
+++ b/docs/wiki/rulebook_sections.md
@@ -1,0 +1,122 @@
+## Adding Custom Sections
+In some rare cases, you may want to add a whole new section of pages to the rulebook.
+This can get pretty technical, so an example has been provided below on how best to set up your new rulebook section.
+
+Once everything is set up, call RuleBookManager.New() with the required arguments and you're good to go.
+```c#
+RuleBookManager.New(
+    MyPluginGuid, // a unique identifier for your mod
+    PageRangeType.Boons, // the PageRangeType we want to inherit our page style from
+    "Mod Tribes", // the subsection name that appears at the end of the header
+    GetInsertPosition, // a Function that determines where in the Rulebook to insert our custom section
+    CreatePages, // the Function to create the pages that will be in our custom section
+    headerPrefix: null, // optional argument, if left null one will be created for you
+    getStartingNumberFunc: GetStartingNumber, // optional argument, if left null the starting number will be 1
+    fillPageAction: FillPage // also optional, but if you want to display custom names, descriptions, etc you will need to set this
+    );
+```
+
+This will return a FullRuleBookRangeInfo object representing your custom section if you want to modify it further.
+
+Note you can pass in STATIC methods as Func and Action arguments when creating your custom rulebook range.
+
+```c#
+// ---IMPORTANT---
+// the return value and parameters MUST match the parameters and return value of the Func
+
+// what part of the rulebook this section should be inserted into
+// since we're using the BoonPage style, this will insert our pages AFTER the Boons section of the rulebook
+private static int GetInsertPosition(PageRangeInfo pageRangeInfo, List<RuleBookPageInfo> pages)
+{
+    return pages.FindLastIndex(rbi => rbi.pagePrefab == pageRangeInfo.rangePrefab) + 1;
+}
+
+private static List<RuleBookPageInfo> CreatePages(RuleBookInfo instance, PageRangeInfo currentRange, AbilityMetaCategory metaCategory)
+{
+    // in this example, we're adding a rulebook section for custom Tribes
+    // foreach custom tribe that exists, we create a rulebook page then set the pageId to the tribe enum so we can use it later
+    List<TribeManager.TribeInfo> allTribes = TribeManager.NewTribes.ToList();
+    List<RuleBookPageInfo> retval = new();
+    foreach (var tribe in allTribes)
+    {
+        RuleBookPageInfo page = new();
+        page.pageId = tribe.tribe.ToString();
+        retval.Add(page);
+    }
+    return retval;
+}
+
+private static int GetStartingNumber(List<RuleBookPageInfo> addedPages)
+{
+    return (int)Tribe.NUM_TRIBES; // since we're doing mod Tribes only, our page numbers will start at 7.
+}
+
+private static void FillPage(RuleBookPage page, string pageId, object[] otherArgs)
+{
+    // in order to modify the page description you MUST convert it to the intended page type as shown
+    if (page is BoonPage boonPage && int.TryParse(pageId, out int id))
+    {
+        TribeManager.TribeInfo tribe = TribeManager.NewTribes.FirstOrDefault(x => x.tribe == (Tribe)id);
+        if (tribe != null)
+        {
+            // We use the internal name of each tribe as our page title
+            // we also replace all instances of the word 'tribe' in the name if they exist so it reads more naturally
+            boonPage.nameTextMesh.text = Localization.Translate(tribe.name.ToLowerInvariant().Replace("tribe", ""));
+            
+            // if we wanted our pages to describe each Tribe, we would set those descriptions here
+            boonPage.descriptionTextMesh.text = "";
+
+            // boon pages have 2 renderers (one on the left and one on the right side of the page)
+            // in this example, we want them to both have the same texture
+            boonPage.iconRenderer.material.mainTexture = boonPage.iconRenderer2.material.mainTexture = tribe.icon.texture;
+        }
+    }
+}
+```
+
+## Useful Information on RuleBookPages
+When filling the content of your custom pages, it's important to understand the page style and what fields you'll have access to.
+
+When your custom section's FillPage() method is called, only certain parts of the current RuleBookPageInfo will be provided to you.
+If you plan on using information beyond the pageId when filling your pages, you need to know the order of objects in the array so you can access them correctly.
+
+### AbilityPage
+Ability icon texture is placed on the left of the page
+
+otherArgs: headerText, ability, fillerAbilityIds
+
+Class Fields:
+- AbilityPageContent *mainAbilityGroup*
+
+### StatIconPage
+Stat Icon texture is placed on the left of the icon's name
+
+otherArgs: headerText
+
+Class Fields:
+- Renderer *iconRenderer*
+- TextMeshPro *nameTextMesh*
+- TextMeshPro *descriptionTextMesh*
+
+### BoonPage
+Boon textures are placed on the left and right of the page (right icon is flipped horizontally)
+
+otherArgs: headerText, boon
+
+Class Fields:
+- Renderer *iconRenderer*
+- Renderer *iconRenderer2*
+- TextMeshPro *nameTextMesh*
+- TextMeshPro *descriptionTextMesh*
+
+### ItemPage
+Item's rulebookSprite is placed on the left of the page
+
+otherArgs: headerText
+
+Class Fields:
+- Renderer *iconRenderer*
+- TextMeshPro *nameTextMesh*
+- TextMeshPro *descriptionTextMesh*
+- Transform *itemModelParent*
+- GameObject *itemModel*

--- a/docs/wiki/toc.yml
+++ b/docs/wiki/toc.yml
@@ -35,8 +35,13 @@ items:
   href: totems.md
 - name: Items
   href: items.md
-- name: Custom Rulebook Section
+- name: The Rulebook
   href: rulebook.md
+  items:
+  - name: Adding Custom Pages
+    href: rulebook_sections.md
+  - name: Adding Text Redirects
+    href: redirect.md
 - name: Asset Bundles
   href: asset_bundle.md
 - name: Sound


### PR DESCRIPTION
- Added AllFullBoons list to BoonManager
- Added FullConsumableItemData to ConsumableItemManager
- Added FullBoon objects for each vanilla Boon
- Added RuleBookManager.GetUnformattedPageId for retrieving a pageId without the API identifier
- Added support for rulebook text redirects
- Added GetFullBoon and GetFullConsumableItemData extension methods
- Added support for boons and items appearing in multiple acts' rulebooks
- Added metaCategories field to FullBoon
- Added BoonShouldBeAdded method to BoonManager
- Added ItemShouldBeAdded method to ConsumableItemPatches
- Fixed RuleBook construction patches having lower patch priority than intended
- Moved ConsumableItemManager patches to ConsumableItemPatches class
- Changed patch to LoadPage from a prefix to a transpiler to avoid mod conflicts
    - modders can modify this transpiler by overriding 
- Tweaked how custom rulebook pages are added and detected
- Tweaked wiki page for adding custom rulebook sections, added additional section on text redirects