### PR TITLE
Fix typos on wiki

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 2.23.7
+- Fixed log spam due to inverted condition in CardExtensions.GemsCost
+
 # 2.23.6
 - Fixed card modifications added to a card's base ice cube card via CardInfo.SetIceCube being ignored
 - Fixed PlayableCard.CanPlay not consistently accounting for temporary mod cost adjustments

--- a/InscryptionAPI/Card/CardExtensionsCosts.cs
+++ b/InscryptionAPI/Card/CardExtensionsCosts.cs
@@ -78,7 +78,7 @@ public static partial class CardExtensions
     /// </summary>
     public static List<GemType> GemsCost(this PlayableCard card)
     {
-        if (card != null && card.Info != null) {
+        if (card == null || card.Info == null) {
             InscryptionAPIPlugin.Logger.LogWarning("[GemsCost] Couldn't find PlayableCard or CardInfo, returning empty list");
             return new();
         }

--- a/InscryptionAPI/InscryptionAPI.csproj
+++ b/InscryptionAPI/InscryptionAPI.csproj
@@ -10,7 +10,7 @@
         <DebugType>full</DebugType>
         <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
         <EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>
-        <Version>2.23.6</Version>
+        <Version>2.23.7</Version>
     </PropertyGroup>
 
     <PropertyGroup>

--- a/InscryptionAPI/InscryptionAPIPlugin.cs
+++ b/InscryptionAPI/InscryptionAPIPlugin.cs
@@ -31,7 +31,7 @@ public class InscryptionAPIPlugin : BaseUnityPlugin
 {
     public const string ModGUID = "cyantist.inscryption.api";
     public const string ModName = "InscryptionAPI";
-    public const string ModVer = "2.23.6";
+    public const string ModVer = "2.23.7";
 
     public static string Directory = "";
 

--- a/InscryptionCommunityPatch/InscryptionCommunityPatch.csproj
+++ b/InscryptionCommunityPatch/InscryptionCommunityPatch.csproj
@@ -9,7 +9,7 @@
         <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
         <DebugType>full</DebugType>
         <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
-        <Version>2.23.0</Version>
+        <Version>2.23.7</Version>
     </PropertyGroup>
 
     <PropertyGroup>

--- a/docs/wiki/custom_costs.md
+++ b/docs/wiki/custom_costs.md
@@ -84,9 +84,9 @@ This is false by default, meaning negative costs on cards will be read as 0 by t
 You can use SetCanBeNegative to change this value, or directly modify the CanBeNegative field.
 
 Cost tier is an integer denoting how expensive a card is, with each cost having its own formula that adds to the tier.
-From example, the formula for Bones' tier is (amount / 3), rounded down.
+For example, the formula for Bones' tier is (amount / 3), rounded down.
 
-By default, custom costs are not accounted when determining a card's cost tier;
+By default, custom costs are not accounted for when determining a card's cost tier;
 this can be fixed using SetCostTier to define the function to use.
 
 ```c#
@@ -106,7 +106,7 @@ public static int CostTier(int amount)
 A vital part of Inscryption's gameplay is the fair hand mechanic;
 when a battle starts, the game will give you at least one card that can be played immediately, as well as a card that can be played by the second turn.
 
-By default, when the game checks if a card with custom costs can be played by turn 2, it will return 2 - even if it can't be.
+By default, when the game checks if a card with custom costs can be played by turn 2, it will return true - even if it can't be.
 
 To fix this, you'll need to set your cost's CanBePlayedByTurn2WithHand function (long name, I know):
 ```c#


### PR DESCRIPTION
Fixes some typos on the wiki. Also reverts a change I made that busted the logic for PlayableCard.GemsCost (not on the public branch fortunately).