### PR TITLE
SteelTrapDeathPatch

### DIFF
--- a/APIPatcher/APIPatcher.csproj
+++ b/APIPatcher/APIPatcher.csproj
@@ -10,13 +10,12 @@
     </PropertyGroup>
 
     <PropertyGroup>
-        <NoWarn>$(NoWarn);AD0001;CS0612;CS0618;Publicizer001</NoWarn>
+        <NoWarn>$(NoWarn);AD0001;CS0612;CS8604;CS0252;CS0618;Harmony003;Publicizer001</NoWarn>
     </PropertyGroup>
 
     <ItemGroup>
-      <PackageReference Include="BepInEx.BaseLib" Version="5.4.19" />
       <PackageReference Include="Inscryption.GameLibs" Version="1.9.0-r.0" />
-      <PackageReference Include="MonoMod" Version="22.3.23.4" />
+      <PackageReference Include="MonoMod" Version="22.7.31.1" />
       <PackageReference Include="UnityEngine.Modules" Version="2019.4.24" />
     </ItemGroup>
 

--- a/APIPatcher/APIPatcher.csproj
+++ b/APIPatcher/APIPatcher.csproj
@@ -1,12 +1,16 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>netstandard2.0</TargetFramework>
+        <TargetFramework>netframework4.7.2</TargetFramework>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>disable</Nullable>
         <LangVersion>latest</LangVersion>
         <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
         <TargetName>Assembly-CSharp.APIPatcher.mm</TargetName>
+    </PropertyGroup>
+
+    <PropertyGroup>
+        <NoWarn>$(NoWarn);AD0001;CS0612;CS0618;Publicizer001</NoWarn>
     </PropertyGroup>
 
     <ItemGroup>
@@ -19,5 +23,4 @@
     <ItemGroup>
       <ProjectReference Private="false" Include="..\InscryptionAPI\InscryptionAPI.csproj" />
     </ItemGroup>
-
 </Project>

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+# 2.24.0
+* Implements the SteelTrapDeathPatch, which is made by Snowi and SpecialAPI.
+* Change to `netframework4.7.2` (closer to the Runtime netframework.)
+* Better NoWarns
+* Implement `GetSteelTrapPelt` and `SetSteelTrapPelt` card extensions
+* Upgrade to API 2.24.0
+* Add a Test Case related to the new patch.
+
 # 2.23.7
 - Fixed log spam due to inverted condition in CardExtensions.GemsCost
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,3 @@
-# 2.24.0
-* Implements the SteelTrapDeathPatch, which is made by Snowi and SpecialAPI.
-* Change to `netframework4.7.2` (closer to the Runtime netframework.)
-* Better NoWarns
-* Implement `GetSteelTrapPelt` and `SetSteelTrapPelt` card extensions
-* Upgrade to API 2.24.0
-* Add a Test Case related to the new patch.
-
 # 2.23.7
 - Fixed log spam due to inverted condition in CardExtensions.GemsCost
 

--- a/InscryptionAPI/Card/CardExtensionsProperties.cs
+++ b/InscryptionAPI/Card/CardExtensionsProperties.cs
@@ -243,4 +243,32 @@ public static partial class CardExtensions
     }
 
     #endregion
+    
+    #region SteelTrapPelt
+    /// <summary>
+    /// Set the Pelt that should be given when this card is slain by a trap.
+    /// </summary>
+    /// <param name="card">The Card this is being applied to.</param>
+    /// <param name="peltName">The Card to be given to the Player on Death by Trap</param>
+    public static void SetSteelTrapPelt(this PlayableCard card, string peltName) => SetSteelTrapPelt(card.Info, peltName);
+    /// <summary>
+    /// Get the Pelt that should be given when this card is slain by a trap.
+    /// </summary>
+    /// <param name="card">The Card this is being applied to.</param>
+    /// <returns>A string representing the Pelt that should be returned.</returns>
+    public static string GetSteelTrapPelt(this PlayableCard card) => GetSteelTrapPelt(card.Info);
+    /// <summary>
+    /// Set the Pelt that should be given when this card is slain by a trap.
+    /// </summary>
+    /// <param name="cardInfo">The CardInfo this is being applied to.</param>
+    /// <param name="peltName">The Card to be given to the Player on Death by Trap</param>
+    public static void SetSteelTrapPelt(this CardInfo cardInfo, string peltName) => cardInfo.SetExtendedProperty("SteelTrapPelt", peltName);
+    /// <summary>
+    /// Get the Pelt that should be given when this card is slain by a trap.
+    /// </summary>
+    /// <param name="cardInfo">The CardInfo this is being applied to.</param>
+    /// <returns>A string representing the Pelt that should be returned.</returns>
+    public static string GetSteelTrapPelt(this CardInfo cardInfo) => cardInfo.GetExtendedProperty("SteelTrapPelt");
+    
+    #endregion
 }

--- a/InscryptionAPI/Card/Patches/SteelTrapDeathPatch.cs
+++ b/InscryptionAPI/Card/Patches/SteelTrapDeathPatch.cs
@@ -1,0 +1,101 @@
+using System.Collections;
+using DiskCardGame;
+using HarmonyLib;
+using Mono.Cecil.Cil;
+using MonoMod.Cil;
+using UnityEngine;
+
+namespace InscryptionAPI.Card;
+
+/// <summary>
+/// Patches the Steal Trap Death system to drop a differed pelt on the case the opposing card has the "SteelTrapPelt" extended property.
+/// </summary>
+/// <remarks>This code is provided by Snowi, and SpecialAPI.</remarks>
+[HarmonyPatch]
+internal static class SteelTrapDeathPatch
+{
+    /// <summary>
+    /// A Transpiler that patches in two functions into the SteelTrap.OnDie function.
+    /// </summary>
+    /// <param name="ctx">The ILContext at the time its being called.</param>
+    /// <remarks>This code is provided by Snowi, and SpecialAPI.</remarks>
+    [HarmonyPatch(typeof(SteelTrap), nameof(SteelTrap.OnDie), MethodType.Enumerator)]
+    [HarmonyILManipulator]
+    private static void CustomSteelTrapPelts_Transpiler(ILContext ctx)
+    {
+        var crs = new ILCursor(ctx);
+ 
+        if (!crs.TryGotoNext(MoveType.Before, x => x.MatchCallOrCallvirt<AbilityBehaviour>(nameof(AbilityBehaviour.PreSuccessfulTriggerSequence))))
+            return;
+ 
+                                   // curr: IEnumerator
+        crs.Emit(OpCodes.Ldloc_1); // SteelTrap
+        crs.Emit(OpCodes.Call, AccessTools.Method(typeof(SteelTrapDeathPatch), nameof(CustomSteelTrapPelts_SetDyingCard))); // ret: void
+ 
+        if (!crs.TryGotoNext(MoveType.After, x => x.MatchCallOrCallvirt<DrawCreatedCard>(nameof(DrawCreatedCard.CreateDrawnCard))))
+            return;
+ 
+                                   // curr: IEnumerator
+        crs.Emit(OpCodes.Ldloc_1); // SteelTrap
+        crs.Emit(OpCodes.Call, AccessTools.Method(typeof(SteelTrapDeathPatch), nameof(CustomSteelTrapPelts_CustomDrawCard))); // ret: IEnumerator
+    }
+ 
+    /// <summary>
+    /// A function which sets the dying card.
+    /// </summary>
+    /// <param name="trap">The SteelTrap ability.</param>
+    /// <remarks>This code is provided by Snowi, and SpecialAPI.</remarks>
+    private static void CustomSteelTrapPelts_SetDyingCard(SteelTrap trap)
+    {
+        var holder = trap.GetComponent<DyingCardHolder>();
+        if (holder == null)
+            holder = trap.gameObject.AddComponent<DyingCardHolder>();
+ 
+        holder.dyingCard = trap?.Card?.Slot?.opposingSlot?.Card?.Info;
+    }
+ 
+    /// <summary>
+    /// The functionality that allows you to get a differed card when a Trap dies, and the current card is the one that perished via "SteelTrapPelt".
+    /// </summary>
+    /// <param name="orig">The IEnumerator origin.</param>
+    /// <param name="trap">The Steel Trap Ability</param>
+    /// <returns>Either the default Wolf Pelt or a custom card if the card that died had a value set for "SteelTrapPelt".</returns>
+    /// <remarks>This code is provided by Snowi, and SpecialAPI.</remarks>
+    private static IEnumerator CustomSteelTrapPelts_CustomDrawCard(IEnumerator orig, SteelTrap trap)
+    {
+        var holder = trap.GetComponent<DyingCardHolder>();
+        if (holder == null || holder.dyingCard == null)
+        {
+            yield return orig;
+            yield break;
+        }
+ 
+        var peltName = holder.dyingCard.GetSteelTrapPelt();
+        if (string.IsNullOrEmpty(peltName))
+        {
+            yield return orig;
+            yield break;
+        }
+ 
+        yield return new WaitForSeconds(0.5f);
+        if (Singleton<ViewManager>.Instance.CurrentView != View.Default)
+        {
+            yield return new WaitForSeconds(0.2f);
+            Singleton<ViewManager>.Instance.SwitchToView(View.Default);
+            yield return new WaitForSeconds(0.2f);
+        }
+        
+        var cardToDraw = CardLoader.GetCardByName(peltName);
+        yield return Singleton<CardSpawner>.Instance.SpawnCardToHand(cardToDraw, null);
+        yield return new WaitForSeconds(0.45f);
+    }
+ 
+    /// <summary>
+    /// The Holder of the dyingCard.
+    /// </summary>
+    /// <remarks>This code is provided by Snowi, and SpecialAPI.</remarks>
+    private class DyingCardHolder : MonoBehaviour
+    {
+        public CardInfo dyingCard;
+    }
+}

--- a/InscryptionAPI/InscryptionAPI.csproj
+++ b/InscryptionAPI/InscryptionAPI.csproj
@@ -14,7 +14,7 @@
     </PropertyGroup>
 
     <PropertyGroup>
-        <NoWarn>$(NoWarn);AD0001;CS0612;CS0618;Publicizer001</NoWarn>
+        <NoWarn>$(NoWarn);AD0001;CS0612;CS8604;CS0252;CS0618;Harmony003;Publicizer001</NoWarn>
     </PropertyGroup>
 
     <ItemGroup>
@@ -35,8 +35,8 @@
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
-        <PackageReference Include="BepInEx.Core" Version="5.4.19" />
-        <PackageReference Include="HarmonyX" Version="2.9.0" />
+        <PackageReference Include="BepInEx.Core" Version="5.4.21" />
+        <PackageReference Include="HarmonyX" Version="2.10.2" />
         <PackageReference Include="Inscryption.GameLibs" Version="1.9.0-r.0" />
         <PackageReference Include="UnityEngine.Modules" Version="2019.4.24" />
     </ItemGroup>

--- a/InscryptionAPI/InscryptionAPI.csproj
+++ b/InscryptionAPI/InscryptionAPI.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>netstandard2.0</TargetFramework>
+        <TargetFramework>netframework4.7.2</TargetFramework>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>disable</Nullable>
         <IsPackable>false</IsPackable>
@@ -14,7 +14,7 @@
     </PropertyGroup>
 
     <PropertyGroup>
-        <NoWarn>Publicizer001</NoWarn>
+        <NoWarn>$(NoWarn);AD0001;CS0612;CS0618;Publicizer001</NoWarn>
     </PropertyGroup>
 
     <ItemGroup>
@@ -40,5 +40,4 @@
         <PackageReference Include="Inscryption.GameLibs" Version="1.9.0-r.0" />
         <PackageReference Include="UnityEngine.Modules" Version="2019.4.24" />
     </ItemGroup>
-
 </Project>

--- a/InscryptionAPI/InscryptionAPIPlugin.cs
+++ b/InscryptionAPI/InscryptionAPIPlugin.cs
@@ -31,7 +31,7 @@ public class InscryptionAPIPlugin : BaseUnityPlugin
 {
     public const string ModGUID = "cyantist.inscryption.api";
     public const string ModName = "InscryptionAPI";
-    public const string ModVer = "2.23.7";
+    public const string ModVer = "2.24.0";
 
     public static string Directory = "";
 

--- a/InscryptionCommunityPatch/InscryptionCommunityPatch.csproj
+++ b/InscryptionCommunityPatch/InscryptionCommunityPatch.csproj
@@ -13,7 +13,7 @@
     </PropertyGroup>
 
     <PropertyGroup>
-        <NoWarn>$(NoWarn);AD0001;CS0612;CS0618;Publicizer001</NoWarn>
+        <NoWarn>$(NoWarn);AD0001;CS0612;CS8604;CS0252;CS0618;Harmony003;Publicizer001</NoWarn>
     </PropertyGroup>
     
     <ItemGroup>
@@ -29,8 +29,8 @@
         <PrivateAssets>all</PrivateAssets>
         <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       </PackageReference>
-      <PackageReference Include="BepInEx.Core" Version="5.4.19" />
-      <PackageReference Include="HarmonyX" Version="2.9.0" />
+      <PackageReference Include="BepInEx.Core" Version="5.4.21" />
+      <PackageReference Include="HarmonyX" Version="2.10.2" />
       <PackageReference Include="Inscryption.GameLibs" Version="1.9.0-r.0" />
       <PackageReference Include="UnityEngine.Modules" Version="2019.4.24" />
     </ItemGroup>

--- a/InscryptionCommunityPatch/InscryptionCommunityPatch.csproj
+++ b/InscryptionCommunityPatch/InscryptionCommunityPatch.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>netstandard2.0</TargetFramework>
+        <TargetFramework>netframework4.7.2</TargetFramework>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>disable</Nullable>
         <IsPackable>false</IsPackable>
@@ -13,7 +13,7 @@
     </PropertyGroup>
 
     <PropertyGroup>
-        <NoWarn>Publicizer001</NoWarn>
+        <NoWarn>$(NoWarn);AD0001;CS0612;CS0618;Publicizer001</NoWarn>
     </PropertyGroup>
     
     <ItemGroup>

--- a/InscryptionCommunityPatch/InscryptionCommunityPatchPlugin.cs
+++ b/InscryptionCommunityPatch/InscryptionCommunityPatchPlugin.cs
@@ -20,7 +20,7 @@ public class PatchPlugin : BaseUnityPlugin
 {
     public const string ModGUID = "community.inscryption.patch";
     public const string ModName = "InscryptionCommunityPatch";
-    public const string ModVer = "1.0.0";
+    public const string ModVer = "2.24.0";
 
     internal static PatchPlugin Instance;
 
@@ -74,6 +74,7 @@ public class PatchPlugin : BaseUnityPlugin
         {
             ExecuteCommunityPatchTests.PrepareForTests();
             TestCost.Init();
+            DebugCards.CreateTestCards();
         }
 
         CommunityArtPatches.PatchCommunityArt();

--- a/InscryptionCommunityPatch/Tests/DebugCards.cs
+++ b/InscryptionCommunityPatch/Tests/DebugCards.cs
@@ -1,0 +1,80 @@
+using DiskCardGame;
+using InscryptionAPI.Card;
+using InscryptionAPI.Guid;
+
+namespace InscryptionCommunityPatch.Tests;
+
+public class DebugCards
+{
+    /// <summary>
+    /// This is an instantiator for a Test Case related to the Steel Trap Death Patch.
+    /// </summary>
+    /// <remarks>This code is provided by Creator/Chaosyr/SaxbyMod/The Stoat Lord.</remarks>
+    public static void CreateTestCards()
+    {
+        CardInfo TestPelt = CreateCardUtil.CreateCard("Test_Pelt", "Test Pelt", 0, 4, new List<Tribe>() { Tribe.Canine });
+        CardInfo Debugger = CreateCardUtil.CreateCard("Debugger", "This is a Debugger", 0, 2, new List<Tribe>() { Tribe.None });
+        CardInfo Debugger2 = CreateCardUtil.CreateCard("Debugger", "This is a Debugger", 0, 2, new List<Tribe>() { Tribe.None });
+        Debugger2.SetExtendedProperty("SteelTrapPelt", PatchPlugin.ModGUID + "_Test_Pelt");
+        Debugger.AddAbilities(Ability.SteelTrap);
+    }
+    
+    /// <summary>
+    /// A Utility for Creating Cards (this is for debug purposes only, so we're tossing a OBSOLETE to be safe.
+    /// </summary>
+    /// <remarks>This code is provided by JamesGames.</remarks>
+    [Obsolete("DO NOT USE THIS, THIS IS FOR DEBUGGING ONLY.")]
+    private class CreateCardUtil
+    {
+        // Code from JamesGames
+        public static CardInfo CreateCard(string name, string displayName, int attack, int health, List<Tribe> tribe)
+        {
+            CardInfo info = CardManager.New(PatchPlugin.ModGUID, name, displayName, attack, health);
+            info.cardComplexity = CardComplexity.Simple;
+            info.AddTraits(Trait.Pelt);
+            foreach (Tribe currentTribe in tribe)
+            {
+                if (currentTribe != Tribe.None)
+                {
+                    info.AddTribes(currentTribe);
+                }
+            }
+            info.temple = CardTemple.Nature;
+            info.AddSpecialAbilities(SpecialTriggeredAbility.SpawnLice);
+            info.AddAppearances(CardAppearanceBehaviour.Appearance.TerrainBackground, CardAppearanceBehaviour.Appearance.TerrainLayout);
+
+            return info;
+        }
+    }
+    
+    /// <summary>
+    /// A Utility for Creating Rare Cards (this is for debug purposes only, so we're tossing a OBSOLETE to be safe.
+    /// </summary>
+    /// <remarks>This code is provided by JamesGames.</remarks>
+    [Obsolete("DO NOT USE THIS, THIS IS FOR DEBUGGING ONLY.")]
+    private class CreateRareCardUtil
+    {
+        // Code from JamesGames
+        public static CardInfo CreateRareCard(string name, string displayName, int attack, int health, List<Tribe> tribe)
+        {
+            CardInfo info = CreateCardUtil.CreateCard(name, displayName, attack, health, tribe);
+            info.AddAppearances(CardAppearanceBehaviour.Appearance.GoldEmission);
+
+            return info;
+        }
+    }
+    
+    /// <summary>
+    /// A Utility for Fetching Tribes (this is for debug purposes only, so we're tossing a OBSOLETE to be safe.
+    /// </summary>
+    /// <remarks>This code is provided by LilySylvee.</remarks>
+    [Obsolete("DO NOT USE THIS, THIS IS FOR DEBUGGING ONLY.")]
+    private class GetCustomTribeUtil
+    {
+        // Code from Lily
+        public static Tribe GetCustomTribe(string GUID, string name)
+        {
+            return GuidManager.GetEnumValue<Tribe>(GUID, name);
+        }
+    }
+}

--- a/NuGet.Config
+++ b/NuGet.Config
@@ -2,5 +2,7 @@
 <configuration>
   <packageSources>
     <add key="BepInEx" value="https://nuget.bepinex.dev/v3/index.json" />
+    <add key="nuget.org" value="https://api.nuget.org/v3/index.json" />
+    <add key="ts-nuget" value="https://nuget.windows10ce.com/nuget/v3/index.json" protocolVersion="3" />
   </packageSources>
 </configuration>

--- a/README.md
+++ b/README.md
@@ -29,6 +29,8 @@ Additionally, a number of quality-of-life patches from the community are include
 ---
 To begin, we'll go over how to install BepInEx, the framework all Inscryption mods use.  This is a necessary step to playing modded Inscryption, so be sure to follow this carefully.
 
+**FOR LINUX AND STEAMDECK:** Ensure that the game is set to run using `Proton` in he game settings on steam. Should be a setting like this: `Change launch behaviour` -> `Proton`.
+
 ### Installing with a Mod Manager
 1. Download and install [Thunderstore Mod Manager](https://www.overwolf.com/app/Thunderstore-Thunderstore_Mod_Manager), [Gale](https://thunderstore.io/c/inscryption/p/Kesomannen/GaleModManager/) or [r2modman](https://thunderstore.io/c/inscryption/p/ebkr/r2modman/).
 2. Click the **Install with Mod Manager** button on the top of [BepInEx's](https://thunderstore.io/c/inscryption/p/BepInEx/BepInExPack_Inscryption/) page.
@@ -41,7 +43,7 @@ If you have issues with Mod Managers head to one of these discords;
 * **Gale Mod Manager Support Discord:** [Here](https://discord.gg/sfuWXRfeTt)
 
 ### Installing Manually
-1. Install [BepInEx](https://thunderstore.io/package/download/BepInEx/BepInExPack_Inscryption/5.4.1902/) by pressing `Manual Download` and extract the contents into a folder. **Do not extract into the game folder!**
+1. Install [BepInEx](https://thunderstore.io/package/download/BepInEx/BepInExPack_Inscryption/5.4.2305/) by pressing `Manual Download` and extract the contents into a folder. **Do not extract into the game folder!**
 2. Move the contents of the `BepInExPack_Inscryption` folder into the game folder (where the game executable is; usually found here: `C:\Program Files (x86)\Steam\steamapps\common\Inscryption`).
 3. Run the game. If everything was done correctly, you will see the BepInEx console appear on your desktop. Close the game after it finishes loading.
 4. Install [MonoModLoader](https://inscryption.thunderstore.io/package/BepInEx/MonoMod_Loader_Inscryption/) and extract the contents into a folder.
@@ -50,51 +52,52 @@ If you have issues with Mod Managers head to one of these discords;
 7. Move the contents of the `plugins` folder into `BepInEx/plugins` and the contents of the `monomod` folder into the `BepInEx/monomod` folder.
 8. Run the game again. If everything runs correctly, a message will appear in the console telling you that the API was loaded.
 9. For any additional mods create a new subfolder, it can be called anything and extract the zips archive into it and if there is a `BepInEx` folder within the zip instead drop the contents of that folder into the `BepInEx` root for the modding instance. EX;
-```
-BepInEx // These go within the BepInEx root folder
-|-- config
-|-- patchers
-|-- plugins
-|-- monomod
-|-- core
-plugins // Files within go into the created plugin subfolder that was created for the mod
-|-- Art
-|-- Scripts
-|-- MyMod.dll
-manifest.json     --|
-README.md           |-- These can be ignored but if you want to keep them put them in the plugin subfolder
-CHANGELOG.md        |--
-icon.png          --|
-```
+    ```
+    BepInEx // These go within the BepInEx root folder
+    |-- config
+    |-- patchers
+    |-- plugins
+    |-- monomod
+    |-- core
+    plugins // Files within go into the created plugin subfolder that was created for the mod
+    |-- Art
+    |-- Scripts
+    |-- MyMod.dll
+    manifest.json // Ignorable, but if kept, goes in plugin subfolder
+    README.md // Ignorable, but if kept, goes in plugin subfolder
+    CHANGELOG.md // Ignorable, but if kept, goes in plugin subfolder
+    icon.png // Ignorable, but if kept, goes in plugin subfolder
+    ```
 10. Run the game once more and everything should be correct and working.
 
 ### Installing Manually (XBOX Game-Pass)
-1. Install [BepInEx](<https://github.com/BepInEx/BepInEx/releases/tag/v5.4.21>) by pressing `BepInEx_x64_5.4.21.0.zip` and extract the contents into a folder.
-2. Move the contents into the game folder (where the game executable is; usually found here: `C:\XboxGames\D30AC640-4EC1-4D15-96F3-384052F09699\Content`).
-3. Run the game. If everything was done correctly, you will see the BepInEx console appear on your desktop. Close the game after it finishes loading. (psst. Enable Logging in `BepInEx/config`)
-4. Install [MonoModLoader](<https://inscryption.thunderstore.io/package/BepInEx/MonoMod_Loader_Inscryption/>) and extract the contents into a folder.
-5. Move the contents of the `patchers` folder into `BepInEx/patchers` (If any of the mentioned BepInEx folders don't exist, just create them).
-6. Install [Inscryption API](<https://inscryption.thunderstore.io/package/API_dev/API/>) and extract the contents into a folder.
-7. Move the contents of the `plugins` folder into `BepInEx/plugins` and the contents of the `monomod` folder into the `BepInEx/monomod` folder.
-8. Run the game again. If everything runs correctly, a message will appear in the console telling you that the API was loaded.
-9. For any additional mods create a new subfolder, it can be called anything and extract the zips archive into it and if there is a `BepInEx` folder within the zip instead drop the contents of that folder into the `BepInEx` root for the modding instance. EX;
-```
-BepInEx // These go within the BepInEx root folder
-|-- config
-|-- patchers
-|-- plugins
-|-- monomod
-|-- core
-plugins // Files within go into the created plugin subfolder that was created for the mod
-|-- Art
-|-- Scripts
-|-- MyMod.dll
-manifest.json     --|
-README.md           |-- These can be ignored but if you want to keep them put them in the plugin subfolder
-CHANGELOG.md        |--
-icon.png          --|
-```
-10. Run the game once more and everything should be correct and working.
+1. Install [BepInEx](https://thunderstore.io/package/download/BepInEx/BepInExPack_Inscryption/5.4.2305/) by pressing `Manual Download` and extract the contents into a folder. **Do not extract into the game folder!**
+2. Move the contents of the `BepInExPack_Inscryption` folder into the game folder (where the game executable is; usually found here: `C:\XboxGames\Inscryption\Content`).
+3. Install the following package: [XboxSilencio](https://thunderstore.io/c/inscryption/p/CORE_API_TEAM/GamepassSilencio/), this is a package which aims to solve frictions with XBOX Gamepass specific installations, such as HueyFS related errors.
+4. Run the game. If everything was done correctly, you will see the BepInEx console appear on your desktop. Close the game after it finishes loading.
+5. Install [MonoModLoader](https://inscryption.thunderstore.io/package/BepInEx/MonoMod_Loader_Inscryption/) and extract the contents into a folder.
+6. Move the contents of the `patchers` folder into `BepInEx/patchers` (If any of the mentioned BepInEx folders don't exist, just create them).
+7. Install [Inscryption API](https://inscryption.thunderstore.io/package/API_dev/API/) and extract the contents into a folder.
+8. Move the contents of the `plugins` folder into `BepInEx/plugins` and the contents of the `monomod` folder into the `BepInEx/monomod` folder.
+9. Run the game again. If everything runs correctly, a message will appear in the console telling you that the API was loaded.
+10. For any additional mods create a new subfolder, it can be called anything and extract the zips archive into it and if there is a `BepInEx` folder within the zip instead drop the contents of that folder into the `BepInEx` root for the modding instance. EX;
+    ```
+    BepInEx // These go within the BepInEx root folder
+    |-- config
+    |-- patchers
+    |-- plugins
+    |-- monomod
+    |-- core
+    plugins // Files within go into the created plugin subfolder that was created for the mod
+    |-- Art
+    |-- Scripts
+    |-- MyMod.dll
+    manifest.json // Ignorable, but if kept, goes in plugin subfolder
+    README.md // Ignorable, but if kept, goes in plugin subfolder
+    CHANGELOG.md // Ignorable, but if kept, goes in plugin subfolder
+    icon.png // Ignorable, but if kept, goes in plugin subfolder
+    ```
+11. Run the game once more and everything should be correct and working.
 
 ### Installing on the Steam Deck
 1. Download [r2modman](https://thunderstore.io/c/inscryption/p/ebkr/r2modman/) on the Steam Deck's Desktop Mode and open it from its download using its `AppImage` file.

--- a/README.md
+++ b/README.md
@@ -263,4 +263,5 @@ Contributors and builders of API 2.0:
 - WhistleWind
 - Windows10CE
 - Keks307
-- ThinCreator3483
+- Creator/Chaosyr/SaxbyMod/The Stoat Lord/ThinCreator3483
+- stillrinny

--- a/README.md
+++ b/README.md
@@ -268,3 +268,4 @@ Contributors and builders of API 2.0:
 - Keks307
 - Creator/Chaosyr/SaxbyMod/The Stoat Lord/ThinCreator3483
 - stillrinny
+- R3b00t3d-kawaii

--- a/docs/wiki/getting_started.md
+++ b/docs/wiki/getting_started.md
@@ -2,6 +2,8 @@
 ---
 To begin, we'll go over how to install BepInEx, the framework all Inscryption mods use.  This is a necessary step to playing modded Inscryption, so be sure to follow this carefully.
 
+**FOR LINUX AND STEAMDECK:** Ensure that the game is set to run using `Proton` in he game settings on steam. Should be a setting like this: `Change launch behaviour` -> `Proton`.
+
 ### Installing with a Mod Manager
 1. Download and install [Thunderstore Mod Manager](https://www.overwolf.com/app/Thunderstore-Thunderstore_Mod_Manager), [Gale](https://thunderstore.io/c/inscryption/p/Kesomannen/GaleModManager/) or [r2modman](https://thunderstore.io/c/inscryption/p/ebkr/r2modman/).
 2. Click the **Install with Mod Manager** button on the top of [BepInEx's](https://thunderstore.io/c/inscryption/p/BepInEx/BepInExPack_Inscryption/) page.
@@ -14,7 +16,7 @@ If you have issues with Mod Managers head to one of these discords;
 * **Gale Mod Manager Support Discord:** [Here](https://discord.gg/sfuWXRfeTt)
 
 ### Installing Manually
-1. Install [BepInEx](https://thunderstore.io/package/download/BepInEx/BepInExPack_Inscryption/5.4.1902/) by pressing `Manual Download` and extract the contents into a folder. **Do not extract into the game folder!**
+1. Install [BepInEx](https://thunderstore.io/package/download/BepInEx/BepInExPack_Inscryption/5.4.2305/) by pressing `Manual Download` and extract the contents into a folder. **Do not extract into the game folder!**
 2. Move the contents of the `BepInExPack_Inscryption` folder into the game folder (where the game executable is; usually found here: `C:\Program Files (x86)\Steam\steamapps\common\Inscryption`).
 3. Run the game. If everything was done correctly, you will see the BepInEx console appear on your desktop. Close the game after it finishes loading.
 4. Install [MonoModLoader](https://inscryption.thunderstore.io/package/BepInEx/MonoMod_Loader_Inscryption/) and extract the contents into a folder.
@@ -23,55 +25,52 @@ If you have issues with Mod Managers head to one of these discords;
 7. Move the contents of the `plugins` folder into `BepInEx/plugins` and the contents of the `monomod` folder into the `BepInEx/monomod` folder.
 8. Run the game again. If everything runs correctly, a message will appear in the console telling you that the API was loaded.
 9. For any additional mods create a new subfolder, it can be called anything and extract the zips archive into it and if there is a `BepInEx` folder within the zip instead drop the contents of that folder into the `BepInEx` root for the modding instance. EX;
-
-```
-BepInEx // These go within the BepInEx root folder
-|-- config
-|-- patchers
-|-- plugins
-|-- monomod
-|-- core
-plugins // Files within go into the created plugin subfolder that was created for the mod
-|-- Art
-|-- Scripts
-|-- MyMod.dll
-manifest.json     --|
-README.md           |-- These can be ignored but if you want to keep them put them in the plugin subfolder
-CHANGELOG.md        |--
-icon.png          --|
-```
-
+    ```
+    BepInEx // These go within the BepInEx root folder
+    |-- config
+    |-- patchers
+    |-- plugins
+    |-- monomod
+    |-- core
+    plugins // Files within go into the created plugin subfolder that was created for the mod
+    |-- Art
+    |-- Scripts
+    |-- MyMod.dll
+    manifest.json // Ignorable, but if kept, goes in plugin subfolder
+    README.md // Ignorable, but if kept, goes in plugin subfolder
+    CHANGELOG.md // Ignorable, but if kept, goes in plugin subfolder
+    icon.png // Ignorable, but if kept, goes in plugin subfolder
+    ```
 10. Run the game once more and everything should be correct and working.
 
 ### Installing Manually (XBOX Game-Pass)
-1. Install [BepInEx](<https://github.com/BepInEx/BepInEx/releases/tag/v5.4.21>) by pressing `BepInEx_x64_5.4.21.0.zip` and extract the contents into a folder.
-2. Move the contents into the game folder (where the game executable is; usually found here: `C:\XboxGames\D30AC640-4EC1-4D15-96F3-384052F09699\Content`).
-3. Run the game. If everything was done correctly, you will see the BepInEx console appear on your desktop. Close the game after it finishes loading. (psst. Enable Logging in `BepInEx/config`)
-4. Install [MonoModLoader](<https://inscryption.thunderstore.io/package/BepInEx/MonoMod_Loader_Inscryption/>) and extract the contents into a folder.
-5. Move the contents of the `patchers` folder into `BepInEx/patchers` (If any of the mentioned BepInEx folders don't exist, just create them).
-6. Install [Inscryption API](<https://inscryption.thunderstore.io/package/API_dev/API/>) and extract the contents into a folder.
-7. Move the contents of the `plugins` folder into `BepInEx/plugins` and the contents of the `monomod` folder into the `BepInEx/monomod` folder.
-8. Run the game again. If everything runs correctly, a message will appear in the console telling you that the API was loaded.
-9. For any additional mods create a new subfolder, it can be called anything and extract the zips archive into it and if there is a `BepInEx` folder within the zip instead drop the contents of that folder into the `BepInEx` root for the modding instance. EX;
-
-```
-BepInEx // These go within the BepInEx root folder
-|-- config
-|-- patchers
-|-- plugins
-|-- monomod
-|-- core
-plugins // Files within go into the created plugin subfolder that was created for the mod
-|-- Art
-|-- Scripts
-|-- MyMod.dll
-manifest.json     --|
-README.md           |-- These can be ignored but if you want to keep them put them in the plugin subfolder
-CHANGELOG.md        |--
-icon.png          --|
-```
-
-10. Run the game once more and everything should be correct and working.
+1. Install [BepInEx](https://thunderstore.io/package/download/BepInEx/BepInExPack_Inscryption/5.4.2305/) by pressing `Manual Download` and extract the contents into a folder. **Do not extract into the game folder!**
+2. Move the contents of the `BepInExPack_Inscryption` folder into the game folder (where the game executable is; usually found here: `C:\XboxGames\Inscryption\Content`).
+3. Install the following package: [XboxSilencio](https://thunderstore.io/c/inscryption/p/CORE_API_TEAM/GamepassSilencio/), this is a package which aims to solve frictions with XBOX Gamepass specific installations, such as HueyFS related errors.
+4. Run the game. If everything was done correctly, you will see the BepInEx console appear on your desktop. Close the game after it finishes loading.
+5. Install [MonoModLoader](https://inscryption.thunderstore.io/package/BepInEx/MonoMod_Loader_Inscryption/) and extract the contents into a folder.
+6. Move the contents of the `patchers` folder into `BepInEx/patchers` (If any of the mentioned BepInEx folders don't exist, just create them).
+7. Install [Inscryption API](https://inscryption.thunderstore.io/package/API_dev/API/) and extract the contents into a folder.
+8. Move the contents of the `plugins` folder into `BepInEx/plugins` and the contents of the `monomod` folder into the `BepInEx/monomod` folder.
+9. Run the game again. If everything runs correctly, a message will appear in the console telling you that the API was loaded.
+10. For any additional mods create a new subfolder, it can be called anything and extract the zips archive into it and if there is a `BepInEx` folder within the zip instead drop the contents of that folder into the `BepInEx` root for the modding instance. EX;
+    ```
+    BepInEx // These go within the BepInEx root folder
+    |-- config
+    |-- patchers
+    |-- plugins
+    |-- monomod
+    |-- core
+    plugins // Files within go into the created plugin subfolder that was created for the mod
+    |-- Art
+    |-- Scripts
+    |-- MyMod.dll
+    manifest.json // Ignorable, but if kept, goes in plugin subfolder
+    README.md // Ignorable, but if kept, goes in plugin subfolder
+    CHANGELOG.md // Ignorable, but if kept, goes in plugin subfolder
+    icon.png // Ignorable, but if kept, goes in plugin subfolder
+    ```
+11. Run the game once more and everything should be correct and working.
 
 ### Installing on the Steam Deck
 1. Download [r2modman](https://thunderstore.io/c/inscryption/p/ebkr/r2modman/) on the Steam Deck's Desktop Mode and open it from its download using its `AppImage` file.


### PR DESCRIPTION
* Implements the SteelTrapDeathPatch, which is made by Snowi and SpecialAPI.
* Change to `netframework4.7.2` (closer to the Runtime netframework.)
* Better NoWarns
* Implement `GetSteelTrapPelt` and `SetSteelTrapPelt` card extensions
* Upgrade to API 2.24.0
* Add a Test Case related to the new patch.
* Update README and CHANGELOG