### PR TITLE
fixed functions related to SacrificablePortraitEmissive settings on a card, which used to refer to the SteelTrapPortrait instead

### DIFF
--- a/InscryptionAPI/Card/CardExtensionsPortraits.cs
+++ b/InscryptionAPI/Card/CardExtensionsPortraits.cs
@@ -635,13 +635,13 @@ public static partial class CardExtensions
     }
     public static CardInfo SetEmissiveSacrificablePortrait(this CardInfo info, Sprite portrait)
     {
-        if (info.SteelTrapPortrait() == null)
+        if (info.SacrificablePortrait() == null)
             throw new InvalidOperationException($"Cannot set emissive portrait before setting the default sacrifice portrait!");
 
-        info.SteelTrapPortrait().RegisterEmissionForSprite(portrait);
+        info.SacrificablePortrait().RegisterEmissionForSprite(portrait);
         return info;
     }
-    public static Sprite GetEmissiveSacrificablePortrait(this CardInfo info) => info.SteelTrapPortrait().GetEmissionSprite();
+    public static Sprite GetEmissiveSacrificablePortrait(this CardInfo info) => info.SacrificablePortrait().GetEmissionSprite();
     #endregion
 
     /// <summary>


### PR DESCRIPTION
Currently, trying to set the emission without a steel trap portrait causes an error saying there is no sacrificable portrait, even if there is one.